### PR TITLE
CGI Logic

### DIFF
--- a/include/cgi/CgiEnv.hpp
+++ b/include/cgi/CgiEnv.hpp
@@ -1,0 +1,15 @@
+#ifndef CGI_ENV_HPP
+#define CGI_ENV_HPP
+
+#include <map>
+#include <string>
+#include "parser/RequestParser.hpp"
+
+class CgiEnv {
+	public:
+	
+	private:
+	
+};
+
+#endif

--- a/include/cgi/CgiEnv.hpp
+++ b/include/cgi/CgiEnv.hpp
@@ -7,9 +7,18 @@
 
 class CgiEnv {
 	public:
+		CgiEnv(const RequestParser& request, const std::string& scriptPath);
+		CgiEnv(const CgiEnv& other);
+		CgiEnv operator=(const CgiEnv& other);
+		~CgiEnv();
+
+		char** getEnv() const;
 	
 	private:
-	
+		std::map<std::string, std::string> _envMap;
+		char** _envp;
+
+		void _buildEnvpArray();
 };
 
 #endif

--- a/include/cgi/CgiHandler.hpp
+++ b/include/cgi/CgiHandler.hpp
@@ -1,0 +1,28 @@
+#ifndef CGI_HANDLER_HPP
+#define CGI_HANDLER_HPP
+
+#include "cgi/CgiEnv.hpp"
+#include "cgi/CgiProcess.hpp"
+#include "parser/RequestParser.hpp"
+#include <string>
+
+class CgiHandler {
+	public:
+		CgiHandler();
+		~CgiHandler();
+
+		// Bartek should call this when he detects a CGI script needs to run.
+		// It returns true if fork/execve succeeded
+		bool init(const RequestParser& request, const std::string& scriptPath, const std::string& cgiExecutable);
+
+		// Bartek should use these to register with his Poller
+		int getWriteFd() const;		// Pipe going INTO the CGI
+		int getReadFd() const;		// Pipe going OUT of the CGI
+		pid_t getPid() const;		// To reap the zombie process later
+	
+	private:
+		CgiEnv* _env;
+		CgiProcess* _process;
+};
+
+#endif

--- a/include/cgi/CgiProcess.hpp
+++ b/include/cgi/CgiProcess.hpp
@@ -1,0 +1,24 @@
+#ifndef CGI_PROCESS_HPP
+#define CGI_PROCESS_HPP
+
+#include <string>
+#include <sys/types.h> //for pid_t
+
+class CgiProcess {
+	public:
+		CgiProcess();
+		~CgiProcess();
+
+		bool execute(const std::string& scriptPath, const std::string& cgiExecutable, char** envp);
+		//Getters for the EventLoop / Poller to regiser these FDs
+		int getServerToCgiFd() const;
+		int getCgiToServerFd() const;
+		pid_t getPid() const;
+
+	private:
+		int _serverToCgiFd; // Server writes to this FD (CGI's stdin)
+		int _cgiToServerFd; // Server reads from this FD (CGI's stdout)
+		pid_t _pid;
+};
+
+#endif

--- a/src/cgi/CgiEnv.cpp
+++ b/src/cgi/CgiEnv.cpp
@@ -1,0 +1,80 @@
+#include "cgi/CgiEnv.hpp"
+#include <cstdlib>
+#include <cstring>
+
+CgiEnv::CgiEnv(const RequestParser& request, const std::string& scriptPath) : _envp(NULL) {
+	// 1. Standard CGI variables
+	_envMap["GATEWAY_INTERFACE"] = "CGI/1.1";
+	_envMap["SERVER_PROTOCOL"] = request.getVersion() ;
+	_envMap["SERVER_SOFTWARE"] = "webserv/1.0";
+	_envMap["REQUEST_METHOD"] = request.getMethod();
+
+	// Split path and query string
+	std::string fullPath = request.getPath();
+	size_t questionMarkPos = fullPath.find('?');
+	if (questionMarkPos != std::string::npos)
+	{
+		_envMap["PATH_INFO"] = fullPath.substr(0, questionMarkPos);
+		_envMap["QUERY_STRING"] = fullPath.substr(questionMarkPos + 1);
+	}
+	else
+	{
+		_envMap["PATH_INFO"] = fullPath;
+		_envMap["QUERY_STRING"] = "";
+	}
+
+	_envMap["SCRIPT_FILENAME"] = scriptPath;
+
+	// 2. HTTP headers mapping
+	const std::map<std::string, std::string>& headers = request.getHeaders();
+	for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it)
+	{
+		std::string key = "HTTP_" + it->first;
+		for (size_t i = 0; i < key.length(); ++i)
+		{
+			if (key[i] == '-')
+				key[i] = '_';
+			key[i] = ::toupper(key[i]);
+		}
+		_envMap[key] = it->second;
+	}
+
+	// Specific handling for Content-Length and Content-Path
+	if (headers.count("Content-Length"))
+	{
+		_envMap["CONTENT_LENGTH"] = headers.at("Content-Length");
+	}
+	if (headers.count("Content-Type"))
+	{
+		_envMap["CONTENT_TYPE"] = headers.at("Content-Type");
+	}
+
+	_buildEnvpArray();
+}
+
+CgiEnv::~CgiEnv() {
+	if (_envp)
+	{
+		for (size_t i = 0; _envp[i] != NULL; ++i)
+		{
+			std::free(_envp[i]);
+		}
+		delete[] _envp;
+	}
+}
+
+void CgiEnv::_buildEnvpArray() {
+	_envp = new char*[_envMap.size() + 1];
+	size_t i = 0;
+	for (std::map<std::string, std::string>::iterator it = _envMap.begin(); it != _envMap.end(); ++it)
+	{
+		std::string envString = it->first + "=" = it->second;
+		_envp[i] = strdup(envString.c_str());
+		i++;
+	}
+	_envp[i] = NULL;
+}
+
+char** CgiEnv::getEnv() const {
+	return _envp;
+}

--- a/src/cgi/CgiHandler.cpp
+++ b/src/cgi/CgiHandler.cpp
@@ -1,0 +1,35 @@
+#include "cgi/CgiHandler.hpp"
+
+CgiHandler::CgiHandler() : _env(NULL), _process(NULL) {}
+CgiHandler::~CgiHandler() {
+	delete _env;
+	delete _process;
+}
+
+bool CgiHandler::init(const RequestParser& request, const std::string& scriptPath, const std::string& cgiExecutable) {
+	_env = new CgiEnv(request, scriptPath);
+	_process = new CgiProcess();
+
+	return _process->execute(scriptPath, cgiExecutable, _env->getEnv());
+}
+
+int CgiHandler::getWriteFd() const {
+	if (_process)
+		return _process->getServerToCgiFd();
+	else
+		return -1;
+}
+
+int CgiHandler::getReadFd() const {
+	if (_process)
+		return _process->getCgiToServerFd();
+	else
+		return -1;
+}
+
+pid_t CgiHandler::getPid() const {
+	if (_process)
+		return _process->getPid();
+	else
+		return -1;
+}

--- a/src/cgi/CgiProcess.cpp
+++ b/src/cgi/CgiProcess.cpp
@@ -1,0 +1,84 @@
+#include "cgi/CgiProcess.hpp"
+#include <iostream>
+// C++ Standard Library wrappers for C functions
+#include <cstdlib>
+#include <cstring>
+// POSIX OS APIs (no C++ equvalent)
+#include <unistd.h> // for pipe, fork, execve, close, dup2
+#include <fcntl.h> // for fcntl, 0_NONBLOCK, FD_CLOEXEC
+#include <sys/types.h> // for pid_t
+
+CgiProcess::CgiProcess() : _serverToCgiFd(-1), _cgiToServerFd(-1), _pid(-1) {}
+CgiProcess::~CgiProcess() {}
+
+bool CgiProcess::execute(const std::string& scriptPath, const std::string& cgiExecutable, char** envp) {
+	int pipe_in[2];
+	int pipe_out[2];
+
+	if (pipe(pipe_in) < 0 || pipe(pipe_out) < 0)
+	{
+		std::cerr << "Pipe creation failed." << std::endl;
+		return false;
+	}
+
+	_pid = fork();
+	if (_pid < 0)
+	{
+		std::cerr << "Fork failed" << std::endl;
+		return false;
+	}
+
+	if (_pid == 0){
+		// CHILD PROCESS
+		close(pipe_in[1]);
+		close(pipe_out[0]);
+
+		dup2(pipe_in[0], STDIN_FILENO);
+		close(pipe_in[0]);
+		dup2(pipe_out[1], STDOUT_FILENO);
+		close(pipe_out[1]);
+
+		char* args[3];
+		args[0] = strdup(cgiExecutable.c_str());
+		args[1] = strdup(scriptPath.c_str());
+		args[2] = NULL;
+
+		size_t lastSlash = scriptPath.find_last_of('/');
+		if (lastSlash != std::string::npos)
+		{
+			std::string dir = scriptPath.substr(0, lastSlash);
+			chdir(dir.c_str());
+		}
+
+		execve(args[0], args, envp);
+
+		std::cerr << "Execve failed" << std::endl;
+		exit(1);
+
+	} else {
+		// PARENT PROCESS
+		close(pipe_in[0]);
+		close(pipe_out[1]);
+
+		_serverToCgiFd = pipe_in[1];
+		_cgiToServerFd = pipe_out[0];
+
+		// Ensuring non-blocking mode
+		fcntl(_serverToCgiFd, F_SETFL, O_NONBLOCK, FD_CLOEXEC);
+		fcntl(_cgiToServerFd, F_SETFL, O_NONBLOCK, FD_CLOEXEC);
+		
+		return true;
+	}
+}
+
+int CgiProcess::getServerToCgiFd() const {
+	return _serverToCgiFd;
+}
+
+int CgiProcess::getCgiToServerFd() const {
+	return _cgiToServerFd;
+}
+
+pid_t CgiProcess::getPid() const {
+	return _pid;
+}

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -44,14 +44,17 @@ def compile_unit_tester():
         "-I../include",
         "unit_tester.cpp",
         "../src/parser/RequestParser.cpp",
-		"../src/network/SocketEngine.cpp",
-		"../src/network/Connection.cpp",
-		"../src/http/StatusCodes.cpp",     # ADDED Przemek tests
+        "../src/network/SocketEngine.cpp",
+        "../src/network/Connection.cpp",
+        "../src/http/StatusCodes.cpp",     # ADDED Przemek tests
         "../src/http/HttpResponse.cpp",    # ADDED Przemek tests
         "../src/http/HttpErrorPage.cpp",   # ADDED Przemek tests
         "../src/http/HttpRequest.cpp",     # ADDED Przemek tests
-		"../src/network/EventLoop.cpp",    # DODANO: Plik Bartka
-		"../src/core/Server.cpp",          # DODANO: Plik Bartka
+        "../src/network/EventLoop.cpp",    # DODANO: Plik Bartka
+        "../src/core/Server.cpp",          # DODANO: Plik Bartka
+        "../src/cgi/CgiHandler.cpp",       # CGI Handler
+        "../src/cgi/CgiProcess.cpp",       # CGI Process
+        "../src/cgi/CgiEnv.cpp",           # CGI Env
         "-o", "unit_tester"
     ]
     res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)

--- a/tests/test_cases/test_07_cgi.py
+++ b/tests/test_cases/test_07_cgi.py
@@ -1,0 +1,47 @@
+import unittest
+import subprocess
+import os
+import sys
+
+class TestCgiModule(unittest.TestCase):
+
+    def setUp(self):
+        """Dynamically create a valid python CGI script before testing"""
+        self.script_path = "dummy.py"
+        with open(self.script_path, "w") as f:
+            f.write("import sys\n")
+            f.write("data = sys.stdin.read()\n")
+            f.write("print('Content-Type: text/plain\\r\\n\\r\\n', end='')\n")
+            f.write("print(f'CGI Response received: {data}')\n")
+        
+        # Give it execution permissions
+        os.chmod(self.script_path, 0o755)
+
+    def tearDown(self):
+        """Clean up the test script after the test completes"""
+        if os.path.exists(self.script_path):
+            os.remove(self.script_path)
+
+    def run_tester(self, component, *args):
+        """Helper to invoke the compiled C++ engine"""
+        cmd = ["./unit_tester", component] + list(args)
+        res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return res.stdout.decode('utf-8')
+
+    def test_cgi_execution_and_io(self):
+        """Verify CgiHandler can spawn a process, pipe data in, and read data out"""
+        
+        # sys.executable securely gets the absolute path to the current python3 binary
+        python_exec = sys.executable 
+        
+        out = self.run_tester("cgi", self.script_path, python_exec)
+        
+        # 1. Assert the initialization didn't fail
+        self.assertNotIn("FAILED_CGI_INIT", out)
+        self.assertIn("SUCCESS_CGI", out)
+        
+        # 2. Assert the CGI Headers and Body were correctly passed back through the pipe
+        self.assertIn("Content-Type: text/plain\r\n\r\n", out)
+        
+        # 3. Assert the CGI correctly read "Hello" from sys.stdin
+        self.assertIn("CGI Response received: Hello", out)

--- a/tests/unit_tester.cpp
+++ b/tests/unit_tester.cpp
@@ -10,6 +10,9 @@
 #include "http/HttpErrorPage.hpp"
 #include "http/HttpRequest.hpp"
 #include "core/Server.hpp"
+#include "cgi/CgiHandler.hpp"
+#include <sys/wait.h>
+#include <fcntl.h>
 
 
 /* 
@@ -187,6 +190,62 @@ else if (component == "socket") {
     else if (component == "connection") {
         // Implement connection testing logic here later
         std::cout << "CONNECTION_TEST_PLACEHOLDER" << std::endl;
+        return 0;
+    }
+
+    // ==========================================
+    // COMPONENT: CGI HANDLER
+    // ==========================================
+    else if (component == "cgi") {
+        if (argc < 4) {
+            std::cerr << "Usage: ./unit_tester cgi [script_path] [exec_path]" << std::endl;
+            return 1;
+        }
+        std::string scriptPath = argv[2];
+        std::string execPath = argv[3];
+
+        // Mock parser payload
+        RequestParser parser;
+        std::string raw_request = "POST /dummy.py HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nHello";
+        parser.feed(raw_request.c_str(), raw_request.length());
+
+        CgiHandler cgi;
+        if (!cgi.init(parser, scriptPath, execPath)) {
+            std::cout << "FAILED_CGI_INIT" << std::endl;
+            return 0;
+        }
+
+        // Simulate Poller Write
+        std::string body = "Hello";
+        write(cgi.getWriteFd(), body.c_str(), body.length());
+        
+		// CRITICAL: Zamykamy potok zapisu. To wysyła EOF do Pythona (sys.stdin.read() się kończy)
+        close(cgi.getWriteFd()); 
+
+        // FIX 1: Czekamy aż skrypt CGI skończy mielić i zamknie swój stdout (zrzuci bufory)
+        int status;
+        waitpid(cgi.getPid(), &status, 0);
+
+        // FIX 2: Wyłączamy O_NONBLOCK dla testowego readera, aby móc normalnie przeczytać bufor w pętli
+        int flags = fcntl(cgi.getReadFd(), F_GETFL, 0);
+        if (flags != -1) {
+            fcntl(cgi.getReadFd(), F_SETFL, flags & ~O_NONBLOCK);
+        }
+
+        // Simulate Poller Read
+        char buffer[1024];
+        std::string output = "";
+        int bytesRead;
+        while ((bytesRead = read(cgi.getReadFd(), buffer, sizeof(buffer) - 1)) > 0) {
+            buffer[bytesRead] = '\0';
+            output += buffer;
+        }
+        close(cgi.getReadFd());
+
+        // Print machine-readable results for Python
+        std::cout << "SUCCESS_CGI" << std::endl;
+        std::cout << output; // Python will read this and assert its contents
+
         return 0;
     }
 


### PR DESCRIPTION
Closes #10,
Closes #21,
Closes #22,
Closes #23.

Environment Variables (Issue #23)
Before we can execute a script (like a PHP or Python file), we need to set up its environment. CGI scripts don't read HTTP headers directly from a socket; they read them from environment variables provided by the web server.

Pipe Setup (Issue #21) & Fork/Exec (Issue #22)
To communicate with the CGI process, we need to replace its standard input (stdin) and standard output (stdout) with pipes.
Pipe IN: Server writes the HTTP request body here -> CGI reads it as stdin.
Pipe OUT: CGI writes its HTML/Response here -> Server reads it from stdout.

1. **`CgiEnv`**: Parses HTTP data into a `char` environment array (Issue #23).
2. **`CgiProcess`**: Handles the `pipe()`, `fork()`, `execve()`, and `fcntl(O_NONBLOCK)` (Issues #21 & #22).
3. **`CgiHandler`**: A "Facade" class that Bartek (Connection, Poller) will interact with. This wraps `CgiEnv` and `CgiProcess` so Bartek doesn't have to understand how they work under the hood (Issue #10)