### PR TITLE
Logger

### DIFF
--- a/include/utils/Logger.hpp
+++ b/include/utils/Logger.hpp
@@ -13,10 +13,10 @@ class Logger {
 			ERROR
 		};
 		// Main logging methods
-		static void debug(std::string& message);
-		static void info(std::string& message);
-		static void warning(std::string& message);
-		static void error(std::string& message);
+		static void debug(const std::string& message);
+		static void info(const std::string& message);
+		static void warning(const std::string& message);
+		static void error(const std::string& message);
 
 		static void setLogLevel(Level level); // to hide DEBUG messages in production
 	private:

--- a/include/utils/Logger.hpp
+++ b/include/utils/Logger.hpp
@@ -1,0 +1,28 @@
+#ifndef LOGGER_HPP
+#define LOGGER_HPP
+
+#include <string>
+
+class Logger {
+	public:
+		// Level definitions
+		enum Level{
+			DEBUG,
+			INFO,
+			WARNING,
+			ERROR
+		};
+		// Main logging methods
+		static void debug(std::string& message);
+		static void info(std::string& message);
+		static void warning(std::string& message);
+		static void error(std::string& message);
+
+		static void setLogLevel(Level level); // to hide DEBUG messages in production
+	private:
+		Logger();                            // private constructor so noone can instantiate Logger log;
+		static Level _currentLevel;
+		static std::string getTimeStamp();
+};
+
+#endif // LOGGER_HPP

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -1,0 +1,58 @@
+#include "utils/Logger.hpp"
+#include <iostream>
+#include <ctime>
+
+// Colours
+#define RESET	"\033[0m"
+#define RED		"\033[31m"
+#define YELLOW	"\033[33m"
+#define CYAN	"\033[36m"
+#define GRAY	"\033[90m"
+
+// Initialize static variable (default INFO level)
+Logger::Level Logger::_currentLevel = Logger::INFO;
+
+void Logger::setLogLevel(Level level){
+	_currentLevel = level;
+}
+
+// Generates a timestamp in the format: YYYY-MM-DD HH:MM:SS
+std::string Logger::getTimeStamp()
+{
+	time_t rawtime;
+	struct tm * timeinfo;
+	char buffer[80];
+
+	time(&rawtime);
+	timeinfo = localtime(&rawtime);
+
+	//Format time
+	strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", timeinfo);
+	return std::string(buffer);
+}
+
+//debug and info write to std::cout, warn and error to std::cerr
+void Logger::debug(const std::string& message)
+{
+	if(_currentLevel <= DEBUG){
+		std::cout << GRAY << "[" << getTimeStamp() << "] [DEBUG]   " << message << RESET << std::endl;
+	}
+}
+void Logger::info(const std::string& message)
+{
+	if(_currentLevel <= INFO){
+		std::cout << CYAN << "[" << getTimeStamp() << "] [INFO]    " << message << RESET << std::endl;
+	}
+}
+void Logger::warning(const std::string& message)
+{
+	if(_currentLevel <= WARNING){
+		std::cerr << YELLOW << "[" << getTimeStamp() << "] [WARNING] " << message << RESET << std::endl;
+	}
+}
+void Logger::error(const std::string& message)
+{
+	if(_currentLevel <= ERROR){
+		std::cerr << RED << "[" << getTimeStamp() << "] [ERROR]   " << message << RESET << std::endl;
+	}
+}

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -10,7 +10,7 @@
 #define GRAY	"\033[90m"
 
 // Initialize static variable (default INFO level)
-Logger::Level Logger::_currentLevel = Logger::INFO;
+Logger::Level Logger::_currentLevel = Logger::DEBUG;
 
 void Logger::setLogLevel(Level level){
 	_currentLevel = level;

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -55,6 +55,7 @@ def compile_unit_tester():
         "../src/cgi/CgiHandler.cpp",       # CGI Handler
         "../src/cgi/CgiProcess.cpp",       # CGI Process
         "../src/cgi/CgiEnv.cpp",           # CGI Env
+		"../src/utils/Logger.cpp",         # Logger
         "-o", "unit_tester"
     ]
     res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)

--- a/tests/unit_tester.cpp
+++ b/tests/unit_tester.cpp
@@ -11,6 +11,7 @@
 #include "http/HttpRequest.hpp"
 #include "core/Server.hpp"
 #include "cgi/CgiHandler.hpp"
+#include "utils/Logger.hpp"
 #include <sys/wait.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
Fixes #68
Logger:
Three main features:
Severity Levels: Not all messages are equal. We typically categorize them into:
DEBUG: Very detailed information, useful only when tracking down a specific bug.
INFO: Normal server operations (e.g., "Server started", "200 OK sent to client").
WARNING: Something unexpected happened, but the server can recover (e.g., "Client requested missing file - 404").
ERROR: A critical failure that might need administrator attention (e.g., "Failed to bind socket to port 80").
Timestamps: Every log entry must state exactly when the event occurred.
Static Accessibility: No need to pass a Logger object to every single class in your project. When the logger's methods are static: you call Logger::info("Message") from anywhere in your code.
Usage:
- Add `#include "utils/Logger.hpp"`
- Use anywhere in the code: `Logger::info("message");`, info might be replaced by any of: debug, info, warning, error
- DEBUG Level messages will be turned off in production system just by changing display level, so might remian in the code and will not be displayed.
The message will be displayed as: 
[Timestamp: YYYY-MM-DD HH:MM:SS] [Log level: DEBUG/INFO/WARNING/ERROR] "message"
![image.png](https://github.com/user-attachments/assets/d014cf3a-5b01-4fc5-a9e1-c2c432816428)
