### PR TITLE
Pjedrycz/issue26 autoindex

### DIFF
--- a/include/http/Autoindex.hpp
+++ b/include/http/Autoindex.hpp
@@ -1,0 +1,36 @@
+#ifndef AUTOINDEX_HPP
+# define AUTOINDEX_HPP
+
+#include "http/HttpResponse.hpp"
+#include <string>
+#include <vector>
+
+class Autoindex
+{
+    public:
+        static std::string buildBody(const std::string &directoryPath, const std::string &requestUri);
+        static HttpResponse buildResponse(const std::string &directoryPath, const std::string &requestUri);
+        static bool tryBuildResponse(const std::string &directoryPath, const std::string &requestUri, HttpResponse &response);
+        
+    private:
+        struct Entry
+        {
+            std::string name;
+            bool isDirectory;
+        };
+    
+    Autoindex();
+    Autoindex(const Autoindex &other);
+    Autoindex &operator=(const Autoindex &other);
+    ~Autoindex();
+
+    static bool readEntries(const std::string &directoryPath, std::vector<Entry> &entries);
+    static bool isDirectory(const std::string &path);
+    static std::string joinPath(const std::string &directoryPath, const std::string &entryName);
+    static std::string ensureTrailingSlash(const std::string &uri);
+    static std::string htmlEscape(const std::string &value);
+    static std::string urlEncode(const std::string &value);
+    static bool entryLess(const Entry &left, const Entry &right);
+};
+
+#endif

--- a/include/http/HttpErrorPage.hpp
+++ b/include/http/HttpErrorPage.hpp
@@ -3,6 +3,7 @@
 
 # include "HttpResponse.hpp"
 # include <string>
+# include <map>
 
 class ErrorPage
 {

--- a/src/http/Autoindex.cpp
+++ b/src/http/Autoindex.cpp
@@ -1,0 +1,198 @@
+#include "../../include/http/Autoindex.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <dirent.h>
+#include <exception>
+#include <sstream>
+#include <sys/stat.h>
+
+namespace
+{
+    class DirGuard
+    {
+    public:
+        explicit DirGuard(DIR *dir) : _dir(dir) {}
+        ~DirGuard()
+        {
+            if (_dir != NULL)
+                closedir(_dir);
+        }
+
+        DIR *get() const
+        {
+            return _dir;
+        }
+
+    private:
+        DirGuard(const DirGuard &other);
+        DirGuard &operator=(const DirGuard &other);
+
+        DIR *_dir;
+    };
+}
+
+std::string Autoindex::buildBody(const std::string &directoryPath, const std::string &requestUri)
+{
+    std::vector<Entry> entries;
+    std::vector<Entry>::const_iterator it;
+    const std::string displayUri = ensureTrailingSlash(requestUri);
+    std::string body;
+
+    if (!readEntries(directoryPath, entries))
+        return std::string();
+    std::sort(entries.begin(), entries.end(), entryLess);
+    body += "<!DOCTYPE html>\n";
+    body += "<html>\n";
+    body += "<head><title>Index of ";
+    body += htmlEscape(displayUri);
+    body += "</title></head>\n";
+    body += "<body>\n";
+    body += "<h1>Index of ";
+    body += htmlEscape(displayUri);
+    body += "</h1>\n";
+    body += "<hr>\n";
+    body += "<pre>";
+    if (displayUri != "/")
+        body += "<a href=\"../\">../</a>\n";
+    for (it = entries.begin(); it != entries.end(); ++it)
+    {
+        const std::string suffix = it->isDirectory ? "/" : "";
+        const std::string visibleName = it->name + suffix;
+        const std::string href = urlEncode(it->name) + suffix;
+
+        body += "<a href=\"";
+        body += href;
+        body += "\">";
+        body += htmlEscape(visibleName);
+        body += "</a>\n";
+    }
+    body += "</pre>\n";
+    body += "<hr>\n";
+    body += "</body>\n";
+    body += "</html>\n";
+    return body;
+}
+
+HttpResponse Autoindex::buildResponse(const std::string &directoryPath, const std::string &requestUri)
+{
+    const std::string body = buildBody(directoryPath, requestUri);
+    HttpResponse response(200, body);
+
+    response.setHeader("Content-Type", "text/html");
+    response.setHeader("Content-Length", HttpResponse::numberToString(body.size()));
+    return response;
+}
+
+bool Autoindex::tryBuildResponse(const std::string &directoryPath, const std::string &requestUri, HttpResponse &response)
+{
+    try
+    {
+        if (!isDirectory(directoryPath))
+            return false;
+        response = buildResponse(directoryPath, requestUri);
+        return !response.getBody().empty();
+    }
+    catch(const std::exception &){}
+    catch(...){}
+    return false;   
+}
+
+bool Autoindex::readEntries(const std::string &directoryPath, std::vector<Entry> &entries)
+{
+    DIR *rawDir = opendir(directoryPath.c_str());
+    struct dirent *dirEntry;
+
+    if (rawDir == NULL)
+        return false;
+    DirGuard dir(rawDir);
+    while ((dirEntry = readdir(dir.get())) != NULL)
+    {
+        const std::string name = dirEntry->d_name;
+        Entry entry;
+
+        if (name == "." || name == "..")
+            continue;
+        entry.name = name;
+        entry.isDirectory = isDirectory(joinPath(directoryPath, name));
+        entries.push_back(entry);
+    }
+    return true;
+}
+
+bool Autoindex::isDirectory(const std::string &path)
+{
+    struct stat info;
+
+    if (stat(path.c_str(), &info) != 0)
+        return false;
+    return S_ISDIR(info.st_mode);
+}
+
+std::string Autoindex::joinPath(const std::string &directoryPath, const std::string &entryName)
+{
+    if (directoryPath.empty() || directoryPath == "/")
+        return "/" + entryName;
+    if (directoryPath[directoryPath.size() - 1] == '/')
+        return directoryPath + entryName;
+    return directoryPath + "/" + entryName;
+}
+
+std::string Autoindex::ensureTrailingSlash(const std::string &uri)
+{
+    if (uri.empty())
+        return "/";
+    if (uri[uri.size() - 1] == '/')
+        return uri;
+    return uri + "/";
+}
+
+std::string Autoindex::htmlEscape(const std::string &value)
+{
+    std::string result;
+    std::string::const_iterator it;
+
+    for (it = value.begin(); it != value.end(); ++it)
+    {
+        if (*it == '&')
+            result += "&amp;";
+        else if (*it == '<')
+            result += "&lt;";
+        else if (*it == '>')
+            result += "&gt;";
+        else if (*it == '"')
+            result += "&quot;";
+        else
+            result += *it;
+    }
+    return result;
+}
+
+std::string Autoindex::urlEncode(const std::string &value)
+{
+    static const char *hex = "0123456789ABCDEF";
+    std::string result;
+    std::string::const_iterator it;
+
+    for (it = value.begin(); it != value.end(); ++it)
+    {
+        const unsigned char c = static_cast<unsigned char>(*it);
+
+        if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+            result += static_cast<char>(c);
+        else
+        {
+            result += '%';
+            result += hex[c >> 4];
+            result += hex[c & 15];
+        }
+    }
+    return result;
+}
+
+bool Autoindex::entryLess(const Entry &left, const Entry &right)
+{
+    if (left.isDirectory != right.isDirectory)
+        return left.isDirectory;
+    return left.name < right.name;
+}


### PR DESCRIPTION
Dodany nowy moduł - Autoindex.

Mamy plik autoindex.cpp i nową klasę - Autoindex.

Mechanika działa tak, żeby request handler/router mógł go użyć w takim flow:

1. Parser requestu odbiera np. GET /files/.
2. Router/config znajduje pasującą lokalizację.
3. Path resolver zamienia URI na ścieżkę katalogu na dysku.
4. Static file handler sprawdza:
  a. czy ścieżka istnieje,
  b. czy to katalog,
  c. czy istnieje plik index, np. index.html,
  d. czy autoindex jest włączony w configu.
5. Jeśli:
  a. zasób jest katalogiem,
  b. nie ma index file,
  c. autoindex on,

wtedy handler wywoła:

`Autoindex::tryBuildResponse(directoryPath, requestUri, response);`

6. Jeśli autoindex się uda, zwracamy 200 OK z HTML listingiem.
7. Jeśli autoindex jest wyłączony albo katalogu nie da się odczytać, request handler powinien później użyć modułu ErrorPage, np. 403 Forbidden albo 404 Not Found.