### PR TITLE
Static files & HTTP responses

### DIFF
--- a/include/filesystem/FileSystem.hpp
+++ b/include/filesystem/FileSystem.hpp
@@ -1,5 +1,25 @@
+#ifndef FILESYSTEM_HPP
+#define FILESYSTEM_HPP
+
+#include <string>
+#include <stdexcept>
+#include <fstream>
+#include <sstream>
+
 class FileSystem
 {
+    private:
+        FileSystem();
+        ~FileSystem();
+        FileSystem(const FileSystem&);
+        FileSystem& operator=(const FileSystem&);
+
+        static std::string getExtension(const std::string& path);
+
     public:
+        static std::string readFile(const std::string& path);
+        static std::string getMimeType(const std::string& path);
         static bool fileExists(const std::string &path);
 };
+
+#endif

--- a/include/http/HttpResponse.hpp
+++ b/include/http/HttpResponse.hpp
@@ -21,6 +21,7 @@ class HttpResponse
         void setBody(const std::string &body);
         void setHeader(const std::string &name, const std::string &value);
         void setConnectionClose(bool closeConnection);
+        void serveStaticFile(const std::string& filePath);
 
         std::string toString() const;
         

--- a/src/filesystem/FileSystem.cpp
+++ b/src/filesystem/FileSystem.cpp
@@ -1,0 +1,48 @@
+#include "filesystem/FileSystem.hpp"
+
+std::string FileSystem::getExtension(const std::string& path)
+{
+    size_t dot_pos = path.find_last_of('.');
+    if (dot_pos == std::string::npos)
+    {
+        return "";
+    }
+    return path.substr(dot_pos);
+}
+
+std::string FileSystem::readFile(const std::string& path)
+{
+    std::ifstream file(path.c_str(), std::ios::in | std::ios::binary);
+
+    if (!file.is_open())
+    {
+        throw std::runtime_error("File not found or permission denied: " + path);
+    }
+
+    std::ostringstream ss;
+    ss << file.rdbuf();
+    return ss.str();
+}
+
+std::string FileSystem::getMimeType(const std::string& path)
+{
+    std::string ext = getExtension(path);
+
+    if (ext == ".html" || ext == ".htm")    return "text/html";
+    if (ext == ".css")                      return "text/css";
+    if (ext == ".js")                       return "application/javascript";
+    if (ext == ".png")                      return "image/png";
+    if (ext == ".jpg" || ext == ".jpeg")    return "image/jpeg";
+    if (ext == ".gif")                      return "imager/gif";
+    if (ext == ".ico")                      return "image/x-icon";
+    if (ext == ".txt")                      return "text/plain";
+    if (ext == ".json")                     return "application/json";
+    
+    return "application/octet-stream"; //default extension for unrecognized file type
+}
+
+bool FileSystem::fileExists(const std::string& path)
+{
+    std::ifstream file(path.c_str());
+    return file.is_open();
+}

--- a/src/http/HttpResponse.cpp
+++ b/src/http/HttpResponse.cpp
@@ -1,5 +1,7 @@
 #include "../../include/http/HttpResponse.hpp"
 #include "../../include/http/StatusCodes.hpp"
+#include "filesystem/FileSystem.hpp"
+#include "http/HttpErrorPage.hpp"
 #include <sstream>
 
 HttpResponse::HttpResponse()
@@ -66,4 +68,20 @@ std::string HttpResponse::numberToString(unsigned long value)
     std::ostringstream output;
     output << value;
     return output.str();
+}
+
+void HttpResponse::serveStaticFile(const std::string& filePath)
+{
+    try
+    {
+        std::string content = FileSystem::readFile(filePath);
+        setStatusCode(200);
+        setBody(content);
+        setHeader("Content-Type", FileSystem::getMimeType(filePath));
+        setHeader("Content-Length", numberToString(content.length()));
+    }
+    catch(const std::exception& e)
+    {
+        ErrorPage::tryBuildDefault(404, *this);
+    }
 }


### PR DESCRIPTION
FileSystem::readFile() czyta pliki i rzuca wyjątkami w przypadku braku uprawnień lub braku pliku
Content-Type dynamicznie dobiera nagłówki na podstawie rozszerzenia
get -> file wepchnąłem sie do pliku httpResponse chyba Przemka ? i dodałem swoją metodę serveStaticFile, która próbuję złożyć wszystko w całość i wyświetlić stronę. Jeśli się nie uda to korzystam z metody tryBuildDefault chyba też Przemka. Także powoli coś składamy do kupy.
Wszystko się kompiluje