### PR TITLE
Keep_alive Timeout  Router Mime Types

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -1,6 +1,12 @@
 server {
     listen 8080;
     server_name localhost;
+
+    location / {
+        root www;
+        allowed_methods GET;
+        autoindex on;
+    }
 }
 
 server {

--- a/include/network/Connection.hpp
+++ b/include/network/Connection.hpp
@@ -3,6 +3,7 @@
 
 #include <unistd.h>
 #include <string>
+#include <ctime>
 #include "parser/RequestParser.hpp"
 
 class Connection // class representing client
@@ -11,6 +12,7 @@ class Connection // class representing client
         int _fd;
         std::string _response_buffer;
         RequestParser _parser;
+        time_t _last_activity;
 
         // Block copy (cannot exist the same FD)
         Connection(const Connection& other);
@@ -26,6 +28,9 @@ class Connection // class representing client
         void appendResponse(const std::string& data);
         std::string& getResponseBuffer();
         void eraseSentData(size_t bytes);
+        void reset();
+        void updateLastActivity();
+        bool isTimedOut(int timeout_second) const;
 };
 
 #endif

--- a/include/network/EventLoop.hpp
+++ b/include/network/EventLoop.hpp
@@ -4,6 +4,8 @@
 #include "network/Poller.hpp"
 #include "network/SocketEngine.hpp"
 #include "network/Connection.hpp"
+#include "core/Config.hpp"
+#include "routing/Router.hpp"
 #include <map>
 #include <stdexcept>
 #include <sys/socket.h>
@@ -17,12 +19,14 @@ class EventLoop
 
         std::map<int, Connection*> _connections;
         std::vector<SocketEngine*> _server_engines;
+        std::vector<ServerConfig>   _servers;
 
         EventLoop(const EventLoop& other);
         EventLoop& operator=(const EventLoop& other);
+        const ServerConfig* matchServerConfig(const std::string& hostHeader) const;
 
     public:
-        EventLoop(const std::vector<SocketEngine*>& engines);
+        EventLoop(const std::vector<SocketEngine*>& engines, const std::vector<ServerConfig>& servers);
         ~EventLoop();
         void run();
 };

--- a/include/routing/Router.hpp
+++ b/include/routing/Router.hpp
@@ -24,6 +24,7 @@ class Router {
 		void handleGet(const std::string& physicalPath, HttpResponse& response) const;
 		void handlePost(const RequestParser& request, std::string& physicalPath, HttpResponse& response) const;
 		void handleDelete(const std::string& physicalPath, HttpResponse& response) const;
+		std::string getMimeType(const std::string& path) const;
 
 };
 

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -80,7 +80,7 @@ void Server::run()
         return;
     }
 
-    EventLoop loop(engines);
+    EventLoop loop(engines, servers);
     loop.run();
 
     for (size_t i = 0; i < engines.size(); ++i)

--- a/src/network/Connection.cpp
+++ b/src/network/Connection.cpp
@@ -6,6 +6,7 @@
 Connection::Connection(int fd) : _fd(fd)
 {
     Logger::info(std::string("New connection created on FD: ") + StringUtils::to_string(_fd));
+    _last_activity = time(NULL);
 }
 
 Connection::~Connection()
@@ -35,4 +36,21 @@ std::string& Connection::getResponseBuffer()
 void Connection::eraseSentData(size_t bytes)
 {
     _response_buffer.erase(0, bytes);
+}
+
+void Connection::reset()
+{
+    _parser = RequestParser();
+    _response_buffer.clear();
+    updateLastActivity();
+}
+
+void Connection::updateLastActivity()
+{
+    _last_activity = time(NULL);
+}
+
+bool Connection::isTimedOut(int timeout_seconds) const
+{
+    return difftime(time(NULL), _last_activity) > timeout_seconds;
 }

--- a/src/network/EventLoop.cpp
+++ b/src/network/EventLoop.cpp
@@ -4,7 +4,8 @@
 #include "http/HttpErrorPage.hpp"
 #include "http/HttpResponse.hpp"
 
-EventLoop::EventLoop(const std::vector<SocketEngine*>& engines) : _is_running(true), _server_engines(engines)
+EventLoop::EventLoop(const std::vector<SocketEngine*>& engines, const std::vector<ServerConfig>& servers)
+	: _is_running(true), _server_engines(engines), _servers(servers)
 {
 	if(_server_engines.empty())
 		throw std::runtime_error("EventLoop initialized with empty SocketEngine list");
@@ -20,13 +21,52 @@ EventLoop::~EventLoop()
 	_connections.clear(); 
 }
 
+const ServerConfig* EventLoop::matchServerConfig(const std::string& hostHeader) const
+{
+	std::string host = hostHeader;
+
+	size_t colon_pos = host.find(':');
+	if (colon_pos != std::string::npos)
+		host = host.substr(0, colon_pos);
+
+	for (size_t i = 0; i < _servers.size(); ++i)
+	{
+		if (_servers[i].serverName == host)
+			return &_servers[i];
+	}
+
+	if (!_servers.empty())
+		return &_servers[0];
+	
+	return NULL;
+}
+
 void EventLoop::run()
 {
 	Logger::info("Starting the minimal event loop...");
+	const int TIMEOUT_LIMIT = 15;
 
 	while (_is_running)
 	{
-		int ready_count = _poller.poll(-1);
+		std::map<int, Connection*>::iterator it = _connections.begin();
+		while (it != _connections.end())
+		{
+			if (it->second->isTimedOut(TIMEOUT_LIMIT))
+			{
+				int timeout_fd = it->first;
+				Logger::warning("Connection timed out. Closing FD " + StringUtils::to_string(timeout_fd));
+				close(timeout_fd);
+				_poller.removeFd(timeout_fd);
+				delete it->second;
+				_connections.erase(it++);
+			}
+			else
+			{
+				++it;
+			}
+		}
+
+		int ready_count = _poller.poll(2000);
 
 		if (ready_count < 0)
 		{
@@ -111,28 +151,36 @@ void EventLoop::run()
 			else
 			{
 				Connection* conn = _connections[current_fd];
+				conn->updateLastActivity();
 				conn->getParser().feed(buffer, bytes_read);
 				RequestParser::ParserState state = conn->getParser().getState();
 
 				if (state == RequestParser::STATE_COMPLETE)
 				{
-					Logger::info("Request fully parsed! Method: " + conn->getParser().getMethod() + " Path: " + conn->getParser().getPath());
+					Logger::info("Request fully parsed! Path: " + conn->getParser().getPath());
 
 					HttpResponse response;
-					std::string method = conn->getParser().getMethod();
-					std::string path = conn->getParser().getPath();
+					const std::map<std::string, std::string>& headers = conn->getParser().getHeaders();
+					std::string host = "";
+					std::map<std::string, std::string>::const_iterator it = headers.find("Host");
+					if (it != headers.end())
+						host = it->second;
+					
+					const ServerConfig* current_config = matchServerConfig(host);
 
-					if (method == "GET")
+					if (current_config != NULL)
 					{
-						if (path == "/") path = "index.html";
+						Router router;
+						for (size_t i = 0; i < current_config->locations.size(); ++i)
+						{
+							router.addLocation(current_config->locations[i]);
+						}
 
-						std::string local_path = "www" + path;
-
-						response.serveStaticFile(local_path);
+						router.route(conn->getParser(), response);
 					}
 					else
 					{
-						ErrorPage::tryBuildDefault(405, response);
+						ErrorPage::tryBuildDefault(500, response);
 					}
 
 					conn->appendResponse(response.toString());
@@ -175,7 +223,29 @@ void EventLoop::run()
 
 				if(conn->getResponseBuffer().empty())
 				{
-					_poller.setEvents(current_fd, POLLIN);
+					const std::map<std::string, std::string>& headers = conn->getParser().getHeaders();
+					bool keep_alive = true;
+
+					std::map<std::string, std::string>::const_iterator it = headers.find("Connection");
+					if (it != headers.end() && it->second == "close")
+					{
+						keep_alive = false;
+					}
+
+					if (keep_alive)
+					{
+						Logger::debug("Keep-Alive: Reseting state for FD " + StringUtils::to_string(current_fd));
+						conn->reset();
+						_poller.setEvents(current_fd, POLLIN);
+					}
+					else
+					{
+						Logger::info("Connection: close requested. Closing FD " + StringUtils::to_string(current_fd));
+						close(current_fd);
+						delete conn;
+						_connections.erase(current_fd);
+						_poller.removeFd(current_fd);
+					}
 				}
 			}
 		}

--- a/src/routing/Router.cpp
+++ b/src/routing/Router.cpp
@@ -1,7 +1,10 @@
 #include "routing/Router.hpp"
 #include "http/HttpErrorPage.hpp"
 #include "utils/Logger.hpp"
+#include "utils/StringUtils.hpp"
 #include <iostream>
+#include <fstream>
+#include <sstream>
 #include <cstdio>
 #include <sys/stat.h>
 
@@ -129,11 +132,58 @@ void Router::handleDelete(const std::string& physicalPath, HttpResponse& respons
 void Router::handleGet(const std::string& physicalPath, HttpResponse& response) const
 {
 	Logger::info("GET request for: " + physicalPath);
-	// TODO: Bartek will handle reading the static file and putting it into 'res' here
+	std::string targetPath = physicalPath;
+	struct stat pathStat;
+	if (stat(targetPath.c_str(), &pathStat) != 0)
+	{
+		Logger::warning("GET eRROR: File not found - " + targetPath);
+		response.setStatusCode(404);
+		response.setBody(ErrorPage::defaultBody(404));
+		return;
+	}
 
-	// For now, just return a dummy success so it compiles
+	if (S_ISDIR(pathStat.st_mode))
+	{
+		if (targetPath[targetPath.length() - 1] != '/')
+			targetPath += "/";
+		targetPath += "index.html";
+	}
+
+	if (stat(targetPath.c_str(), &pathStat) != 0 || S_ISDIR(pathStat.st_mode))
+	{
+		Logger::warning("GET Error: Index file not found in directory - " + targetPath);
+		// TODO: "Directorty listing (autoindex)" - Przemek
+		response.setStatusCode(403);
+		response.setBody(ErrorPage::defaultBody(403));
+		return;
+	}
+	// check permission for read
+	if (!(pathStat.st_mode & S_IRUSR))
+	{
+		Logger::warning("GET Error: Permission denied - " + targetPath);
+		response.setStatusCode(403);
+		response.setBody(ErrorPage::defaultBody(403));
+		return;
+	}
+
+	std::ifstream file(targetPath.c_str(), std::ios::in | std::ios::binary);
+	if (!file.is_open())
+	{
+		Logger::error("GET Error: Could not open file - " + targetPath);
+		response.setStatusCode(500);
+		response.setBody(ErrorPage::defaultBody(500));
+		return;
+	}
+
+	std::ostringstream ss;
+	ss << file.rdbuf();
+	file.close();
+
 	response.setStatusCode(200);
-	response.setBody(ErrorPage::defaultBody(200));
+	response.setHeader("Content-Length", StringUtils::to_string(ss.str().length()));
+	response.setHeader("Content-Type", getMimeType(targetPath));
+	response.setBody(ss.str());
+	Logger::info("GET Success: Loaded " + StringUtils::to_string(ss.str().length()) + " bytes from " + targetPath);
 }
 
 void Router::handlePost(const RequestParser& request, std::string& physicalPath, HttpResponse& response) const
@@ -147,4 +197,25 @@ void Router::handlePost(const RequestParser& request, std::string& physicalPath,
 	// For now, just return a dummy success so it compiles
 	response.setStatusCode(200);
 	response.setBody(ErrorPage::defaultBody(200));
+}
+
+std::string Router::getMimeType(const std::string& path) const
+{
+	size_t dotPos = path.find_last_of('.');
+	if (dotPos == std::string::npos)
+		return "application/octet-stream";
+	std::string ext = path.substr(dotPos);
+
+	if (ext == ".html" || ext == ".htm") return "text/html";
+	if (ext == ".css") return "text/css";
+	if (ext == ".js") return "application/javascript";
+	if (ext == ".jpg" || ext == ".jpeg") return "image/jpeg";
+	if (ext == ".png") return "image/png";
+	if (ext == ".gif") return "image/gif";
+	if (ext == ".ico") return "image/x-icon";
+	if (ext == ".txt") return "text/plain";
+	if (ext == ".json") return "application/json";
+	if (ext == ".pdf") return "application/pdf";
+
+	return "application/octet-stream";
 }


### PR DESCRIPTION
Jest dużo, ale uznałem, że trochę nie mamy czasu, żeby teraz dzielić wszystko na pojedyncze PR. Na dole wygenerowana lista, która mam nadzieję trochę pomoże.
Co zrobiłem (lub było zrobione wcześniej):
-Używamy poll(), co pozwala obsłużyć wielu klientów na raz bez blokowania serwera.
-Po wysłaniu odpowiedzi serwer nie ucina kabla, tylko grzecznie czyści bufory i czeka na kolejne zapytania od tego samego klienta (dzięki temu ładują się poboczne pliki jak CSS).
-System ma "miotłę", która bezlitośnie odcina klientów, którzy połączyli się, ale nic nie wysyłają przez 15 sekund.
-Router potrafi otworzyć plik, sprawdzić, czy masz do niego prawa, wczytać go do pamięci i wysłać z poprawnym nagłówkiem Content-Length.
-Serwer wie, czy wysyła tekst, obrazek czy arkusz stylów, dzięki nowej funkcji dopasowującej MIME Types na podstawie rozszerzenia (np. .css, .png).