### PR TITLE
Two files changed: HttpResponse.cpp and Router.cpp

### DIFF
--- a/src/http/HttpResponse.cpp
+++ b/src/http/HttpResponse.cpp
@@ -52,14 +52,29 @@ std::string HttpResponse::toString() const
     std::ostringstream output;
     HeaderMap::const_iterator it;
 
+    bool hasContentLength = false;
+    bool bodyAllowed = !(_statusCode >= 100 && _statusCode < 200) && _statusCode != 204 && _statusCode != 304;
+
     output << "HTTP/1.1 " << _statusCode << " "
            << HttpStatus::reasonPhrase(_statusCode) << "\r\n";
     for (it = _headers.begin(); it != _headers.end(); ++it)
+    {
+        if (it->first == "Content-Length")
+        {
+            hasContentLength = true;
+            continue;
+        }
         output << it->first << ": " << it->second << "\r\n";
+    }
+    if (bodyAllowed)
+        output << "Content-Length: " << _body.size() << "\r\n";
     if (_closeConnection)
         output << "Connection: close\r\n";
     output << "\r\n";
-    output << _body;
+
+    if (bodyAllowed)
+        output << _body;
+
     return output.str(); 
 }
 

--- a/src/routing/Router.cpp
+++ b/src/routing/Router.cpp
@@ -220,8 +220,8 @@ void Router::handleDelete(const std::string& physicalPath, HttpResponse& respons
 	if (std::remove(physicalPath.c_str()) == 0)
 	{
 		Logger::info("DELETE Success: " +  physicalPath);
-		response.setStatusCode(202);
-		response.setBody(ErrorPage::defaultBody(204));
+		response.setStatusCode(204);
+		response.setBody("");
 	}
 	else
 	{


### PR DESCRIPTION
Changes in two files:

1. HttpResponse.cpp - now calculates and emits exactly one correct Content-Length for responses that may contain a body. It omits both body and length for 1xx, 204, and 304.
2. Router.cpp - now returns 204 No Content with an empty body after successful DELETE.