### PR TITLE
Location based max body limit

### DIFF
--- a/include/routing/LocationConfig.hpp
+++ b/include/routing/LocationConfig.hpp
@@ -13,6 +13,7 @@ class LocationConfig {
 		// Setters for optional config directives
 		void setAutoindex(bool enabled);
 		void setUpload(bool enabled, const std::string& storePath = "");
+		void setClientMaxBodySize(size_t maxBodySize);
 
 		bool isMethodAllowed(const std::string& method) const;
 		const std::string& getPath() const;
@@ -20,6 +21,7 @@ class LocationConfig {
 		bool getAutoindex() const;
 		bool isUploadEnabled() const;
 		const std::string& getUploadStore() const;
+		size_t getClientMaxBodySize() const;
 
 	private:
 		std::string _path; // e.g. "/images/"
@@ -29,6 +31,7 @@ class LocationConfig {
 		bool _autoindex;
 		bool _uploadEnabled;
 		std::string _uploadStore;
+		size_t _clientMaxBodySize;
 };
 
 #endif // LOCATIONCONFIG_HPP

--- a/include/routing/Router.hpp
+++ b/include/routing/Router.hpp
@@ -19,6 +19,7 @@ class Router {
 		std::vector<LocationConfig> _locations;
 		const LocationConfig* matchLocation(const std::string& uri) const;
 		std::string translatePath(const std::string& uri, const LocationConfig* location) const;
+		bool isBodyTooLarge(const RequestParser& request, const LocationConfig* location) const;
 
 		// method handlers
 		void handleGet(const std::string& requestUri, const std::string& physicalPath, const LocationConfig* location, HttpResponse& response) const;

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -159,6 +159,7 @@ void Config::parseLocationBlock(ServerConfig& server)
 	bool autoindex = false;
 	bool uploadEnabled = false;
 	std::string uploadStore = "";
+	size_t clientMaxBodySize = 0;
 
 	while (_currentTokenIndex < _tokens.size() && _tokens[_currentTokenIndex] != "}")
 	{
@@ -208,6 +209,14 @@ void Config::parseLocationBlock(ServerConfig& server)
 			if(_currentTokenIndex >= _tokens.size() || _tokens[_currentTokenIndex++] != ";")
 				throw std::runtime_error("Expacted ';' after upload_store");
 		}
+		else if (directive == "client_max_body_size")
+		{
+			if (_currentTokenIndex >= _tokens.size())
+				throw std::runtime_error("Unexpected EOF after client_max_body_size");
+			clientMaxBodySize = static_cast<size_t>(std::atoi(_tokens[_currentTokenIndex++].c_str()));
+			if (_currentTokenIndex >= _tokens.size() || _tokens[_currentTokenIndex++] != ";")
+				throw std::runtime_error("Expected ';' after client_max_body_size directive");
+		}
 		else
 		{
 			throw std::runtime_error("Unknown directive in location block: " + directive);
@@ -229,6 +238,7 @@ void Config::parseLocationBlock(ServerConfig& server)
 	{
 		newLocation.setUpload(true,uploadStore);
 	}
+	newLocation.setClientMaxBodySize(clientMaxBodySize);
 	server.locations.push_back(newLocation);
 }
 

--- a/src/http/HttpResponse.cpp
+++ b/src/http/HttpResponse.cpp
@@ -52,7 +52,6 @@ std::string HttpResponse::toString() const
     std::ostringstream output;
     HeaderMap::const_iterator it;
 
-    bool hasContentLength = false;
     bool bodyAllowed = !(_statusCode >= 100 && _statusCode < 200) && _statusCode != 204 && _statusCode != 304;
 
     output << "HTTP/1.1 " << _statusCode << " "
@@ -60,10 +59,7 @@ std::string HttpResponse::toString() const
     for (it = _headers.begin(); it != _headers.end(); ++it)
     {
         if (it->first == "Content-Length")
-        {
-            hasContentLength = true;
             continue;
-        }
         output << it->first << ": " << it->second << "\r\n";
     }
     if (bodyAllowed)

--- a/src/network/EventLoop.cpp
+++ b/src/network/EventLoop.cpp
@@ -25,13 +25,34 @@ EventLoop::~EventLoop()
 
 size_t EventLoop::getMaxBodySizeForPort(int port) const
 {
+	size_t maxBodySize = 0;
+	bool hasUnlimited = false;
+
 	for (size_t i = 0; i < _servers.size(); ++i)
 	{
 		if (_servers[i].port == port)
-			return _servers[i].clientMaxBodySize;
+		{
+			if (_servers[i].clientMaxBodySize == 0)
+				hasUnlimited = true;
+			else if (_servers[i].clientMaxBodySize > maxBodySize)
+				maxBodySize = _servers[i].clientMaxBodySize;
+
+			for (size_t j = 0; j < _servers[i].locations.size(); ++j)
+			{
+				const size_t locationLimit = _servers[i].locations[j].getClientMaxBodySize();
+				if (locationLimit == 0)
+					hasUnlimited = true;
+				else if (locationLimit > maxBodySize)
+					maxBodySize = locationLimit;
+			}
+		}
 	}
 
-	return 1048576;
+	if (hasUnlimited)
+		return 0;
+	if (maxBodySize == 0)
+		return 1048576;
+	return maxBodySize;
 }
 
 const ServerConfig* EventLoop::matchServerConfig(const std::string& hostHeader) const

--- a/src/routing/LocationConfig.cpp
+++ b/src/routing/LocationConfig.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 
 LocationConfig::LocationConfig(const std::string& path, const std::string& root) : 
-_path(path), _root(root), _autoindex(false), _uploadEnabled(false), _uploadStore("") {}
+_path(path), _root(root), _allowedMethods(), _autoindex(false), _uploadEnabled(false), _uploadStore(""), _clientMaxBodySize(0) {}
 
 void LocationConfig::addAllowedMethod(const std::string& method)
 {
@@ -19,6 +19,11 @@ void LocationConfig::setUpload(bool enabled, const std::string& storePath)
 {
 	_uploadEnabled = enabled;
 	_uploadStore = storePath;
+}
+
+void LocationConfig::setClientMaxBodySize(size_t maxBodySize)
+{
+	_clientMaxBodySize = maxBodySize;
 }
 
 bool LocationConfig::isMethodAllowed(const std::string& method) const
@@ -49,4 +54,9 @@ bool LocationConfig::isUploadEnabled() const
 const std::string& LocationConfig::getUploadStore() const
 {
 	return _uploadStore;
+}
+
+size_t LocationConfig::getClientMaxBodySize() const
+{
+	return _clientMaxBodySize;
 }

--- a/src/routing/Router.cpp
+++ b/src/routing/Router.cpp
@@ -188,6 +188,13 @@ void Router::route(const RequestParser& request, HttpResponse& response) const
 		return;
 	}
 
+	if (isBodyTooLarge(request, location))
+	{
+		Logger::warning("Router: request body too large for route " + location->getPath());
+		response = ErrorPage::buildDefault(413);
+		return;
+	}
+
 	// 3. Translate the path and route to the correct handler
 	std::string physicalPath = translatePath(request.getPath(), location);
 
@@ -202,6 +209,15 @@ void Router::route(const RequestParser& request, HttpResponse& response) const
 		response.setStatusCode(501);
 		response.setBody(ErrorPage::defaultBody(501));
 	}
+}
+
+bool Router::isBodyTooLarge(const RequestParser& request, const LocationConfig* location) const
+{
+	if (!location)
+		return false;
+	if (location->getClientMaxBodySize() == 0)
+		return false;
+	return request.getBody().size() > location->getClientMaxBodySize();
 }
 
 void Router::handleDelete(const std::string& physicalPath, HttpResponse& response) const
@@ -319,6 +335,12 @@ void Router::handleGet(const std::string& requestUri, const std::string& physica
 
 void Router::handlePost(const RequestParser& request, const LocationConfig* location, HttpResponse& response) const
 {
+	if (isBodyTooLarge(request, location))
+	{
+		response = ErrorPage::buildDefault(413);
+		return;
+	}
+
 	if (location != NULL && location->isUploadEnabled())
 	{
 		const std::map<std::string, std::string>& headers = request.getHeaders();

--- a/tests/test_cases/test_09_config.py
+++ b/tests/test_cases/test_09_config.py
@@ -17,6 +17,7 @@ class TestConfigParser(unittest.TestCase):
 
                 location /api {
                     root /var/www/api;
+                    client_max_body_size 1024;
                     allowed_methods GET POST;
                     autoindex on;
                     upload_enable on;
@@ -54,6 +55,7 @@ class TestConfigParser(unittest.TestCase):
         # Check Location block rules
         self.assertIn("Loc Path: /api", out)
         self.assertIn("Loc Root: /var/www/api", out)
+        self.assertIn("Loc Max Body Size: 1024", out)
         self.assertIn("Autoindex: on", out)
         self.assertIn("Upload: on", out)
         self.assertIn("Upload Store: /var/www/uploads", out)

--- a/tests/test_cases/test_eval_live_server.py
+++ b/tests/test_cases/test_eval_live_server.py
@@ -57,6 +57,11 @@ class TestEvaluationLiveServer(unittest.TestCase):
         root %s;
         allowed_methods GET POST;
     }
+    location /limited {
+        root %s;
+        allowed_methods POST;
+        client_max_body_size 8;
+    }
     location /listing {
         root %s/listing;
         allowed_methods GET;
@@ -85,8 +90,8 @@ server {
         allowed_methods GET;
     }
 }
-""" % (cls.PORT, cls.root, cls.root, cls.root, cls.delete_root,
-       cls.upload_root, cls.upload_root, cls.PORT, cls.vhost_root))
+""" % (cls.PORT, cls.root, cls.root, cls.root, cls.root, cls.delete_root,
+    cls.upload_root, cls.upload_root, cls.PORT, cls.vhost_root))
 
         cls.server = run_tests.start_main_server(cls.config_path)
         cls.wait_until_listening()
@@ -162,6 +167,11 @@ server {
         response = self.send_raw_request(
             "POST /post HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2048\r\n\r\n" + body)
         self.assertTrue(response.startswith("HTTP/1.1 200"), response)
+
+    def test_route_body_size_limit(self):
+        response = self.send_raw_request(
+            "POST /limited HTTP/1.1\r\nHost: localhost\r\nContent-Length: 9\r\n\r\nAAAAAAAAA")
+        self.assertTrue(response.startswith("HTTP/1.1 413"), response)
 
     def test_chunked_post(self):
         response = self.send_raw_request(

--- a/tests/unit_tester.cpp
+++ b/tests/unit_tester.cpp
@@ -308,6 +308,7 @@ else if (component == "socket") {
                 for (size_t j = 0; j < servers[i].locations.size(); ++j) {
                     std::cout << "Loc Path: " << servers[i].locations[j].getPath() << std::endl;
                     std::cout << "Loc Root: " << servers[i].locations[j].getRoot() << std::endl;
+                    std::cout << "Loc Max Body Size: " << servers[i].locations[j].getClientMaxBodySize() << std::endl;
                     std::cout << "Autoindex: " << (servers[i].locations[j].getAutoindex() ? "on" : "off") << std::endl;
                     std::cout << "Upload: " << (servers[i].locations[j].isUploadEnabled() ? "on" : "off") << std::endl;
                     std::cout << "Upload Store: " << servers[i].locations[j].getUploadStore() << std::endl;
@@ -318,6 +319,7 @@ else if (component == "socket") {
         } else {
             std::cout << "FAILED_CONFIG_PARSER" << std::endl;
         }
+        return 0;
     }
     // ==========================================
     // COMPONENT: AUTOINDEX


### PR DESCRIPTION
Added per route (location based) client_max_body_limit.
Fixes #101 - Per-route request body limit
Required changed in LocationConfig, Config and Router.
Route-level body limits are now wired through the same config path as the rest of the location settings. The new directive is parsed inside location blocks, stored on the matched location, and enforced in the router after the location match so oversized POST requests return 413 at route scope.

Removed the dead flag in src/http/HttpResponse.cpp (hasContentLength). toString() already skips any existing Content-Length header and always writes a fresh one from the body size, so hasContentLength was never needed and only triggered -Werror=unused-but-set-variable.

I also added/modified testing harness.
