### PR TITLE
Add files via upload

### DIFF
--- a/include/parser/RequestParser.hpp
+++ b/include/parser/RequestParser.hpp
@@ -39,6 +39,7 @@ class RequestParser
 		const std::string &getMethod() const;
 		MethodState getMethodState() const;
 		const std::string &getPath() const;
+		const std::string &getQuery() const;
 		const std::string &getVersion() const;
 		const std::map<std::string, std::string> &getHeaders() const;
 		const std::vector<char> &getBody() const;
@@ -57,6 +58,7 @@ class RequestParser
 
 		std::string _method;
 		std::string _path;
+		std::string _query;
 		std::string _version;
 		std::map<std::string, std::string> _headers;
 		std::vector<char> _body;
@@ -64,6 +66,7 @@ class RequestParser
 		std::string _headerBuffer;
 		size_t _contentLength;
 		size_t _bytesRead;
+		size_t _headerBytes;
 		
 		enum ChunkState{
 			CHUNK_SIZE,
@@ -83,6 +86,11 @@ class RequestParser
 		std::string trim(const std::string &str);
 		bool parseRequestLine(const std::string &line);
 		bool parseHeaderLine(const std::string &line);
+		static char toLowerAscii(char c);
+		static std::string normalizeHeaderName(const std::string &value);
+		static bool isTokenChar(char c);
+		static bool parseDecimalSize(const std::string &value, size_t &result);
+		static bool parseHexSize(const std::string &value, size_t &result);
 };
 
 #endif

--- a/include/routing/LocationConfig.hpp
+++ b/include/routing/LocationConfig.hpp
@@ -16,6 +16,7 @@ class LocationConfig {
 		void setClientMaxBodySize(size_t maxBodySize);
 
 		bool isMethodAllowed(const std::string& method) const;
+		std::string getAllowedMethodsHeader() const;
 		const std::string& getPath() const;
 		const std::string& getRoot() const;
 		bool getAutoindex() const;

--- a/src/cgi/CgiEnv.cpp
+++ b/src/cgi/CgiEnv.cpp
@@ -2,6 +2,13 @@
 #include <cstdlib>
 #include <cstring>
 
+static char toUpperAscii(char c)
+{
+	if (c >= 'a' && c <= 'z')
+		return static_cast<char>(c - 'a' + 'A');
+	return c;
+}
+
 CgiEnv::CgiEnv(const RequestParser& request, const std::string& scriptPath) : _envp(NULL) {
 	// 1. Standard CGI variables
 	_envMap["GATEWAY_INTERFACE"] = "CGI/1.1";
@@ -9,19 +16,8 @@ CgiEnv::CgiEnv(const RequestParser& request, const std::string& scriptPath) : _e
 	_envMap["SERVER_SOFTWARE"] = "webserv/1.0";
 	_envMap["REQUEST_METHOD"] = request.getMethod();
 
-	// Split path and query string
-	std::string fullPath = request.getPath();
-	size_t questionMarkPos = fullPath.find('?');
-	if (questionMarkPos != std::string::npos)
-	{
-		_envMap["PATH_INFO"] = fullPath.substr(0, questionMarkPos);
-		_envMap["QUERY_STRING"] = fullPath.substr(questionMarkPos + 1);
-	}
-	else
-	{
-		_envMap["PATH_INFO"] = fullPath;
-		_envMap["QUERY_STRING"] = "";
-	}
+	_envMap["PATH_INFO"] = request.getPath();
+	_envMap["QUERY_STRING"] = request.getQuery();
 
 	_envMap["SCRIPT_FILENAME"] = scriptPath;
 
@@ -34,20 +30,18 @@ CgiEnv::CgiEnv(const RequestParser& request, const std::string& scriptPath) : _e
 		{
 			if (key[i] == '-')
 				key[i] = '_';
-			key[i] = ::toupper(key[i]);
+			key[i] = toUpperAscii(key[i]);
 		}
 		_envMap[key] = it->second;
 	}
 
-	// Specific handling for Content-Length and Content-Path
-	if (headers.count("Content-Length"))
-	{
-		_envMap["CONTENT_LENGTH"] = headers.at("Content-Length");
-	}
-	if (headers.count("Content-Type"))
-	{
-		_envMap["CONTENT_TYPE"] = headers.at("Content-Type");
-	}
+	// CGI exposes these two entity headers without the HTTP_ prefix.
+	std::map<std::string, std::string>::const_iterator contentLength = headers.find("content-length");
+	if (contentLength != headers.end())
+		_envMap["CONTENT_LENGTH"] = contentLength->second;
+	std::map<std::string, std::string>::const_iterator contentType = headers.find("content-type");
+	if (contentType != headers.end())
+		_envMap["CONTENT_TYPE"] = contentType->second;
 
 	_buildEnvpArray();
 }
@@ -57,7 +51,7 @@ CgiEnv::~CgiEnv() {
 	{
 		for (size_t i = 0; _envp[i] != NULL; ++i)
 		{
-			std::free(_envp[i]);
+			delete[] _envp[i];
 		}
 		delete[] _envp;
 	}
@@ -68,8 +62,11 @@ void CgiEnv::_buildEnvpArray() {
 	size_t i = 0;
 	for (std::map<std::string, std::string>::iterator it = _envMap.begin(); it != _envMap.end(); ++it)
 	{
-		std::string envString = it->first + "=" = it->second;
-		_envp[i] = strdup(envString.c_str());
+		std::string envString = it->first + "=" + it->second;
+		_envp[i] = new char[envString.size() + 1];
+		for (size_t j = 0; j < envString.size(); ++j)
+			_envp[i][j] = envString[j];
+		_envp[i][envString.size()] = '\0';
 		i++;
 	}
 	_envp[i] = NULL;

--- a/src/cgi/CgiProcess.cpp
+++ b/src/cgi/CgiProcess.cpp
@@ -39,8 +39,10 @@ bool CgiProcess::execute(const std::string& scriptPath, const std::string& cgiEx
 		close(pipe_out[1]);
 
 		char* args[3];
-		args[0] = strdup(cgiExecutable.c_str());
-		args[1] = strdup(scriptPath.c_str());
+		// execve does not modify argv strings.  The std::string objects remain
+		// alive until execve replaces this child process.
+		args[0] = const_cast<char*>(cgiExecutable.c_str());
+		args[1] = const_cast<char*>(scriptPath.c_str());
 		args[2] = NULL;
 
 		size_t lastSlash = scriptPath.find_last_of('/');

--- a/src/network/EventLoop.cpp
+++ b/src/network/EventLoop.cpp
@@ -204,7 +204,7 @@ void EventLoop::run()
 					HttpResponse response;
 					const std::map<std::string, std::string>& headers = conn->getParser().getHeaders();
 					std::string host = "";
-					std::map<std::string, std::string>::const_iterator it = headers.find("Host");
+					std::map<std::string, std::string>::const_iterator it = headers.find("host");
 					if (it != headers.end())
 						host = it->second;
 					
@@ -277,7 +277,7 @@ void EventLoop::run()
 					bool keep_alive = conn->getParser().getState() != RequestParser::STATE_ERROR
 						&& conn->getParser().getState() != RequestParser::STATE_PAYLOAD_TOO_LARGE;
 
-					std::map<std::string, std::string>::const_iterator it = headers.find("Connection");
+					std::map<std::string, std::string>::const_iterator it = headers.find("connection");
 					if (it != headers.end() && it->second == "close")
 					{
 						keep_alive = false;

--- a/src/parser/RequestParser.cpp
+++ b/src/parser/RequestParser.cpp
@@ -31,11 +31,70 @@ static bool isImplementedMethod(const std::string& method)
 
 RequestParser::RequestParser(size_t maxBodySize) 
 	: _state(STATE_REQUEST_LINE), _bodyType(BODY_NONE),
-	_methodState(METHOD_UNKNOWN), _method(), _path(), _version(), _headers(), _body(),
-	_headerBuffer(), _contentLength(0), _bytesRead(0),
+	_methodState(METHOD_UNKNOWN), _method(), _path(), _query(), _version(), _headers(), _body(),
+	_headerBuffer(), _contentLength(0), _bytesRead(0), _headerBytes(0),
 	_chunkState(CHUNK_SIZE), _currentChunkSize(0), _chunkHexBuffer(),
 	_maxBodySize(maxBodySize), _oversizedBodyDrained(false)
 {
+}
+
+char RequestParser::toLowerAscii(char c)
+{
+	if (c >= 'A' && c <= 'Z')
+		return static_cast<char>(c - 'A' + 'a');
+	return c;
+}
+
+std::string RequestParser::normalizeHeaderName(const std::string &value)
+{
+	std::string result(value);
+	for (size_t i = 0; i < result.size(); ++i)
+		result[i] = toLowerAscii(result[i]);
+	return result;
+}
+
+bool RequestParser::isTokenChar(char c)
+{
+	if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+		|| (c >= '0' && c <= '9'))
+		return true;
+	return c == '!' || c == '#' || c == '$' || c == '%' || c == '&'
+		|| c == '\'' || c == '*' || c == '+' || c == '-' || c == '.'
+		|| c == '^' || c == '_' || c == '`' || c == '|' || c == '~';
+}
+
+bool RequestParser::parseDecimalSize(const std::string &value, size_t &result)
+{
+	result = 0;
+	if (value.empty())
+		return false;
+	for (size_t i = 0; i < value.size(); ++i)
+	{
+		if (value[i] < '0' || value[i] > '9'
+			|| result > (static_cast<size_t>(-1) - static_cast<size_t>(value[i] - '0')) / 10)
+			return false;
+		result = result * 10 + static_cast<size_t>(value[i] - '0');
+	}
+	return true;
+}
+
+bool RequestParser::parseHexSize(const std::string &value, size_t &result)
+{
+	result = 0;
+	if (value.empty())
+		return false;
+	for (size_t i = 0; i < value.size(); ++i)
+	{
+		size_t digit;
+		if (value[i] >= '0' && value[i] <= '9') digit = value[i] - '0';
+		else if (value[i] >= 'a' && value[i] <= 'f') digit = value[i] - 'a' + 10;
+		else if (value[i] >= 'A' && value[i] <= 'F') digit = value[i] - 'A' + 10;
+		else return false;
+		if (result > (static_cast<size_t>(-1) - digit) / 16)
+			return false;
+		result = result * 16 + digit;
+	}
+	return true;
 }
 
 std::string RequestParser::trim(const std::string &str)
@@ -71,6 +130,13 @@ bool RequestParser::parseRequestLine(const std::string &line)
 	if(_method.empty() || _path.empty() || _path[0] != '/')
 		return false;
 
+	const std::string::size_type queryPos = _path.find('?');
+	if (queryPos != std::string::npos)
+	{
+		_query = _path.substr(queryPos + 1);
+		_path.erase(queryPos);
+	}
+
 	if (isImplementedMethod(_method))
 		_methodState = METHOD_IMPLEMENTED;
 	else if (isRecognizedMethod(_method))
@@ -102,23 +168,16 @@ bool RequestParser::parseHeaderLine(const std::string &line)
 		return false;
  	}
 
-	size_t i = 0;
-	while(i < key.size())
-	{
-		if(key[i] == ' ' || key[i] == '\t')
-			return false;
-		i++;
-	}
-
-	if (key == "Content-Length")
-	{
-		char *endptr;
-		long parsedLength = std::strtol(value.c_str(), &endptr, 10);
-		if (endptr == value.c_str() || *endptr != '\0' || parsedLength < 0)
+	for (size_t i = 0; i < key.size(); ++i)
+		if (!isTokenChar(key[i]))
 			return false;
 
-		_contentLength = static_cast<size_t>(parsedLength);
-	}
+	key = normalizeHeaderName(key);
+	if ((key == "host" || key == "content-length" || key == "transfer-encoding")
+		&& _headers.find(key) != _headers.end())
+		return false;
+	if (key == "content-length" && !parseDecimalSize(value, _contentLength))
+		return false;
 
 	_headers[key] = value;
 	return true;
@@ -137,6 +196,11 @@ RequestParser::MethodState RequestParser::getMethodState() const
 const std::string &RequestParser::getPath() const
 {
 	return _path;
+}
+
+const std::string &RequestParser::getQuery() const
+{
+	return _query;
 }
 
 const std::string &RequestParser::getVersion() const
@@ -168,33 +232,37 @@ RequestParser::ParseState RequestParser::getParseState() const
 {
 	if (_state == STATE_COMPLETE)
 		return PARSE_SUCCESS;
-	if (_state == STATE_ERROR || _state == STATE_PAYLOAD_TOO_LARGE)
+	if (_state == STATE_ERROR || (_state == STATE_PAYLOAD_TOO_LARGE && _oversizedBodyDrained))
 		return PARSE_ERROR;
 	return PARSE_INCOMPLETE;
 }
 
 void RequestParser::determineBodyType()
 {
-	std::map<std::string, std::string>::const_iterator it = _headers.find("Transfer-Encoding");
-	if(it != _headers.end() && it->second.find("chunked") != std::string::npos)
+	const bool hasLength = _headers.find("content-length") != _headers.end();
+	const bool hasTransfer = _headers.find("transfer-encoding") != _headers.end();
+	if (hasLength && hasTransfer)
 	{
-		_bodyType = BODY_CHUNKED;
+		_state = STATE_ERROR;
 		return;
 	}
-	//If not chunked, check for Content-Length
-	it = _headers.find("Content-Length");
-	if(it != _headers.end())
+	std::map<std::string, std::string>::const_iterator it = _headers.find("transfer-encoding");
+	if (hasTransfer)
 	{
-		_bodyType = BODY_CONTENT_LENGTH;
-		char *endptr;
-		long parsedLength = std::strtol(it->second.c_str(), &endptr, 10);
-		if (endptr == it->second.c_str() || *endptr != '\0' || parsedLength < 0)
+		std::string transferEncoding = normalizeHeaderName(trim(it->second));
+		if (transferEncoding != "chunked")
 		{
 			_state = STATE_ERROR;
 			return;
 		}
-
-		_contentLength = static_cast<size_t>(parsedLength);
+		_bodyType = BODY_CHUNKED;
+		return;
+	}
+	//If not chunked, check for Content-Length
+	it = _headers.find("content-length");
+	if(hasLength)
+	{
+		_bodyType = BODY_CONTENT_LENGTH;
 		if (_maxBodySize != 0 && _contentLength > _maxBodySize)
 		{
 			_state = STATE_PAYLOAD_TOO_LARGE;
@@ -228,11 +296,21 @@ void RequestParser::feed(const char* data, size_t length)
 	size_t i = 0;
 	while(i < length && _state != STATE_BODY && _state != STATE_ERROR && _state != STATE_COMPLETE && _state != STATE_PAYLOAD_TOO_LARGE)
 	{
+		if (++_headerBytes > 32768)
+		{
+			_state = STATE_ERROR;
+			return;
+		}
 		_headerBuffer += data[i];
 		if(_headerBuffer.size() >= 2 && _headerBuffer.substr(_headerBuffer.size() - 2) == "\r\n")
 		{
 			std::string line = _headerBuffer.substr(0, _headerBuffer.size() - 2);
 			_headerBuffer.clear();
+			if (_state == STATE_REQUEST_LINE && line.size() > 8192)
+			{
+				_state = STATE_ERROR;
+				return;
+			}
 
 			if(line.empty())
 			{
@@ -304,19 +382,15 @@ void RequestParser::processBody(const char* data, size_t length)
 				if(_chunkHexBuffer.size() >= 2 && _chunkHexBuffer.substr(_chunkHexBuffer.size() - 2) == "\r\n")
 				{
 					std::string size_line = _chunkHexBuffer.substr(0, _chunkHexBuffer.size() - 2);
-					char* endptr;
-					long parsed_size = std::strtol(size_line.c_str(), &endptr, 16);
-					// Validation checks:
-					// 1. endptr == size_line.c_str() means no digits were parsed at all
-					// 2. *endptr != '\0' means there were training invalid chars (like 'Z')
-					// 3. parsed_size < 0 protects against overflow or negative values
-					if (endptr == size_line.c_str() || *endptr != '\0' || parsed_size < 0)
+					const std::string::size_type extensionPos = size_line.find(';');
+					if (extensionPos != std::string::npos)
+						size_line.erase(extensionPos);
+					if (!parseHexSize(size_line, _currentChunkSize))
 					{
 						_state = STATE_ERROR;
 					}
 					else
 					{
-						_currentChunkSize = static_cast<size_t>(std::strtol(size_line.c_str(), NULL, 16));
 						if (_maxBodySize != 0 && _body.size() + _currentChunkSize > _maxBodySize)
 						{
 							_state = STATE_PAYLOAD_TOO_LARGE;

--- a/src/routing/LocationConfig.cpp
+++ b/src/routing/LocationConfig.cpp
@@ -33,6 +33,18 @@ bool LocationConfig::isMethodAllowed(const std::string& method) const
 	return (std::find(_allowedMethods.begin(), _allowedMethods.end(), method) != _allowedMethods.end());
 }
 
+std::string LocationConfig::getAllowedMethodsHeader() const
+{
+	std::string methods;
+	for (size_t i = 0; i < _allowedMethods.size(); ++i)
+	{
+		if (i != 0)
+			methods += ", ";
+		methods += _allowedMethods[i];
+	}
+	return methods;
+}
+
 const std::string& LocationConfig::getPath() const
 {
 	return _path;

--- a/src/routing/Router.cpp
+++ b/src/routing/Router.cpp
@@ -152,8 +152,7 @@ void Router::route(const RequestParser& request, HttpResponse& response) const
 	if (request.getState() == RequestParser::STATE_PAYLOAD_TOO_LARGE)
 	{
 		Logger::warning("Router: Payload too large.");
-		response.setStatusCode(413);
-		response.setBody(ErrorPage::defaultBody(413));
+		response = ErrorPage::buildDefault(413);
 		return;
 	}
 
@@ -184,9 +183,7 @@ void Router::route(const RequestParser& request, HttpResponse& response) const
 	if (location == NULL)
 	{
 		Logger::info("Router: No location found for " + request.getPath());
-		response.setStatusCode(404);
-		// somehow here need to build 404 error page. Not sure if used interface properly
-		response.setBody(ErrorPage::defaultBody(404));
+		response = ErrorPage::buildDefault(404);
 		return;
 	}
 
@@ -194,9 +191,8 @@ void Router::route(const RequestParser& request, HttpResponse& response) const
 	if (!location->isMethodAllowed(request.getMethod()))
 	{
 		Logger::warning("Router: 405 Method Not Allowed (" + request.getMethod() + ") for " + request.getPath());
-		response.setStatusCode(405);
-		// somehow here need to build 405 error page. Not sure if used interface properly
-		response.setBody(ErrorPage::defaultBody(405));
+		response = ErrorPage::buildDefault(405);
+		response.setHeader("Allow", location->getAllowedMethodsHeader());
 		return;
 	}
 
@@ -218,8 +214,7 @@ void Router::route(const RequestParser& request, HttpResponse& response) const
 		handleDelete(physicalPath, response);
 	} else {
 		// Handle 501 Not Implemented (for methods like PUT, PATCH if not implemented)
-		response.setStatusCode(501);
-		response.setBody(ErrorPage::defaultBody(501));
+		response = ErrorPage::buildDefault(501);
 	}
 }
 
@@ -239,8 +234,7 @@ void Router::handleDelete(const std::string& physicalPath, HttpResponse& respons
 	if (stat(physicalPath.c_str(), &buffer) != 0)
 	{
 		Logger::info("DELETE Error: File not found - " + physicalPath);
-		response.setStatusCode(404);
-		response.setBody(ErrorPage::defaultBody(404));
+		response = ErrorPage::buildDefault(404);
 		return;
 	}
 
@@ -254,8 +248,7 @@ void Router::handleDelete(const std::string& physicalPath, HttpResponse& respons
 	else
 	{
 		Logger::info("[INFO] DELETE Error: Forbidden/No Access - " + physicalPath);
-		response.setStatusCode(403);
-		response.setBody(ErrorPage::defaultBody(403));
+		response = ErrorPage::buildDefault(403);
 	}
 }
 
@@ -272,8 +265,7 @@ void Router::handleGet(const std::string& requestUri, const std::string& physica
 	if (stat(targetPath.c_str(), &pathStat) != 0)
 	{
 		Logger::warning("GET eRROR: File not found - " + targetPath);
-		response.setStatusCode(404);
-		response.setBody(ErrorPage::defaultBody(404));
+		response = ErrorPage::buildDefault(404);
 		return;
 	}
 
@@ -312,16 +304,14 @@ void Router::handleGet(const std::string& requestUri, const std::string& physica
 	if (stat(targetPath.c_str(), &pathStat) != 0 || S_ISDIR(pathStat.st_mode))
 	{
 		Logger::warning("GET Error: Index file not found in directory - " + targetPath);
-		response.setStatusCode(403);
-		response.setBody(ErrorPage::defaultBody(403));
+		response = ErrorPage::buildDefault(403);
 		return;
 	}
 	// check permission for read
 	if (!(pathStat.st_mode & S_IRUSR))
 	{
 		Logger::warning("GET Error: Permission denied - " + targetPath);
-		response.setStatusCode(403);
-		response.setBody(ErrorPage::defaultBody(403));
+		response = ErrorPage::buildDefault(403);
 		return;
 	}
 
@@ -329,8 +319,7 @@ void Router::handleGet(const std::string& requestUri, const std::string& physica
 	if (!file.is_open())
 	{
 		Logger::error("GET Error: Could not open file - " + targetPath);
-		response.setStatusCode(500);
-		response.setBody(ErrorPage::defaultBody(500));
+		response = ErrorPage::buildDefault(500);
 		return;
 	}
 
@@ -356,7 +345,7 @@ void Router::handlePost(const RequestParser& request, const LocationConfig* loca
 	if (location != NULL && location->isUploadEnabled())
 	{
 		const std::map<std::string, std::string>& headers = request.getHeaders();
-		std::map<std::string, std::string>::const_iterator contentType = headers.find("Content-Type");
+		std::map<std::string, std::string>::const_iterator contentType = headers.find("content-type");
 		std::string boundary;
 		std::string filename;
 		std::string fileBody;


### PR DESCRIPTION
Fixes #102

Files changed:
- RequestParser.hpp
- LocationConfig.hpp
- CgiEnv.cpp
- CgiProcess.cpp
- EventLoop.cpp
- RequestParser.cpp
- LocationConfig.cpp
- Router.cpp

Changes:

1. Case-insensitive normalized request headers, duplicate framing-header rejection, Transfer-Encoding + Content-Length rejection, header/request-line limits, chunk extensions, and query-string separation in [RequestParser.cpp (line 41)](/home/przemek/Documents/42Warsaw/Projects/Core/webserv/webserv-przemek-issue102/src/parser/RequestParser.cpp:41).

2. HTTP/1.1 Host and Connection lookups now use normalized header names in [EventLoop.cpp (line 207)](/home/przemek/Documents/42Warsaw/Projects/Core/webserv/webserv-przemek-issue102/src/network/EventLoop.cpp:207).

3. Upload Content-Type lookup updated in [Router.cpp (line 359)](/home/przemek/Documents/42Warsaw/Projects/Core/webserv/webserv-przemek-issue102/src/routing/Router.cpp:359).

4. Proper Allow header on 405 responses via [LocationConfig.cpp (line 31)](/home/przemek/Documents/42Warsaw/Projects/Core/webserv/webserv-przemek-issue102/src/routing/LocationConfig.cpp:31).

5. CGI receives separate PATH_INFO / QUERY_STRING, normalized headers, and no longer uses toupper, strdup, or map::at in [CgiEnv.cpp (line 5)](/home/przemek/Documents/42Warsaw/Projects/Core/webserv/webserv-przemek-issue102/src/cgi/CgiEnv.cpp:5).

6. Removed remaining CGI strdup usage in [CgiProcess.cpp (line 42)](/home/przemek/Documents/42Warsaw/Projects/Core/webserv/webserv-przemek-issue102/src/cgi/CgiProcess.cpp:42).