### PR TITLE
Add files via upload

### DIFF
--- a/config/interface-example.conf
+++ b/config/interface-example.conf
@@ -1,0 +1,19 @@
+# Numeric-only listen values remain valid and bind all IPv4 interfaces:
+#     listen 8080;
+# A hostname or IPv4 address can select a specific interface:
+#     listen localhost:8080;
+# IPv6 literals must be bracketed:
+#     listen [::1]:8080;
+#
+# This form binds only the loopback interface, so the server is not exposed
+# on the local network.
+server {
+    listen 127.0.0.1:8081;
+    server_name localhost;
+
+    location / {
+        root www;
+        allowed_methods GET;
+        autoindex on;
+    }
+}

--- a/include/core/Config.hpp
+++ b/include/core/Config.hpp
@@ -8,13 +8,14 @@
 
 // Represents a single server {} block from the config file
 struct ServerConfig {
+	std::string host;
 	int port;
 	std::string serverName;
 	std::vector<LocationConfig> locations;
 	size_t clientMaxBodySize;
 
 	// clientMaxBodySize: Default to 1MB (1048576 bytes) if not specified, or 0 for unlimited
-	ServerConfig() : port(8080), serverName("localhost"), clientMaxBodySize(1048576) {}
+	ServerConfig() : host("0.0.0.0"), port(8080), serverName("localhost"), clientMaxBodySize(1048576) {}
 };
 
 class Config {
@@ -34,6 +35,7 @@ class Config {
 		void tokenize(const std::string& fileContent);
 		void parseServerBlock();
 		void parseLocationBlock(ServerConfig& server);
+		static bool parseListenValue(const std::string& value, std::string& host, int& port);
 
 };
 

--- a/include/network/Connection.hpp
+++ b/include/network/Connection.hpp
@@ -12,6 +12,8 @@ class Connection // class representing client
         int _fd;
         std::string _response_buffer;
         RequestParser _parser;
+		std::string _listening_host;
+		int _listening_port;
         time_t _last_activity;
         size_t _max_body_size;
 
@@ -20,10 +22,13 @@ class Connection // class representing client
         Connection& operator=(const Connection& other);
 
     public:
-        Connection(int fd, size_t maxBodySize = 1048576);
+        Connection(int fd, size_t maxBodySize = 1048576,
+			const std::string& listeningHost = "0.0.0.0", int listeningPort = 0);
         ~Connection();
 
         int getFd() const;
+		const std::string& getListeningHost() const;
+		int getListeningPort() const;
         RequestParser& getParser() { return _parser; }
 
         void appendResponse(const std::string& data);

--- a/include/network/EventLoop.hpp
+++ b/include/network/EventLoop.hpp
@@ -23,8 +23,9 @@ class EventLoop
 
         EventLoop(const EventLoop& other);
         EventLoop& operator=(const EventLoop& other);
-        const ServerConfig* matchServerConfig(const std::string& hostHeader) const;
-        size_t getMaxBodySizeForPort(int port) const;
+		const ServerConfig* matchServerConfig(const std::string& hostHeader,
+			const std::string& listeningHost, int listeningPort) const;
+        size_t getMaxBodySizeForEndpoint(const std::string& host, int port) const;
 
     public:
         static bool is_running;

--- a/include/network/SocketEngine.hpp
+++ b/include/network/SocketEngine.hpp
@@ -2,9 +2,9 @@
 #define SOCKET_ENGINE_HPP
 
 #include <string>
-#include <netinet/in.h>
 #include "Connection.hpp"
 #include <sys/socket.h>
+#include <netdb.h>
 #include <fcntl.h>
 #include <cstring>
 #include <stdexcept>
@@ -14,20 +14,22 @@ class SocketEngine
 {
     private:
         int         _server_fd;
+		std::string _host;
         int         _port;
-        struct sockaddr_in _address;
 
         SocketEngine(const SocketEngine& other);
         SocketEngine& operator=(const SocketEngine& other);
 
     public:
         SocketEngine(int port);
+		SocketEngine(const std::string& host, int port);
         ~SocketEngine();
 
         void init();
         Connection* acceptConnection(size_t maxBodySize);
         int getFd() const;        
         int getPort() const;
+		const std::string& getHost() const;
 };
 
 #endif

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -8,6 +8,49 @@
 Config::Config() : _currentTokenIndex(0) {}
 Config::~Config() {}
 
+bool Config::parseListenValue(const std::string& value, std::string& host, int& port)
+{
+	std::string portText = value;
+	if (!value.empty() && value[0] == '[')
+	{
+		const std::string::size_type closingBracket = value.find(']');
+		if (closingBracket == std::string::npos || closingBracket == 1
+			|| closingBracket + 1 >= value.size() || value[closingBracket + 1] != ':')
+			return false;
+		host = value.substr(1, closingBracket - 1);
+		portText = value.substr(closingBracket + 2);
+	}
+	else
+	{
+		const std::string::size_type colon = value.rfind(':');
+		if (colon != std::string::npos)
+		{
+			if (colon == 0 || colon != value.find(':'))
+				return false;
+			host = value.substr(0, colon);
+			portText = value.substr(colon + 1);
+		}
+		else
+			host = "0.0.0.0";
+	}
+	if (portText.empty())
+		return false;
+
+	unsigned long parsedPort = 0;
+	for (size_t i = 0; i < portText.size(); ++i)
+	{
+		if (portText[i] < '0' || portText[i] > '9')
+			return false;
+		parsedPort = parsedPort * 10 + static_cast<unsigned long>(portText[i] - '0');
+		if (parsedPort > 65535)
+			return false;
+	}
+	if (parsedPort == 0)
+		return false;
+	port = static_cast<int>(parsedPort);
+	return true;
+}
+
 void Config::tokenize(const std::string& fileContent)
 {
 	std::string token = "";
@@ -96,6 +139,7 @@ bool Config::loadConfig(const std::string& filename)
 void Config::parseServerBlock()
 {
 	ServerConfig newServer;
+	bool hasListenDirective = false;
 
 	while (_currentTokenIndex < _tokens.size() && _tokens[_currentTokenIndex] != "}")
 	{
@@ -105,9 +149,14 @@ void Config::parseServerBlock()
 		{
 			if(_currentTokenIndex >= _tokens.size()) 
 				throw std::runtime_error("Unexpected EOF after listen");
-			newServer.port = std::atoi(_tokens[_currentTokenIndex++].c_str());
+			if (hasListenDirective)
+				throw std::runtime_error("Only one listen directive is allowed per server block");
+			const std::string listenValue = _tokens[_currentTokenIndex++];
+			if (!parseListenValue(listenValue, newServer.host, newServer.port))
+				throw std::runtime_error("Invalid listen value: " + listenValue);
 			if (_currentTokenIndex >= _tokens.size() || _tokens[_currentTokenIndex++] != ";")
 				throw std::runtime_error("Expected ';' after listen directive");
+			hasListenDirective = true;
 		}
 		else if (directive == "server_name")
 		{
@@ -139,6 +188,8 @@ void Config::parseServerBlock()
 	{
 		throw std::runtime_error("Unexpected end of file, missing '}' for server block ");
 	}
+	if (!hasListenDirective)
+		throw std::runtime_error("Server block is missing a listen directive");
 
 	_currentTokenIndex++; // Skip '}'
 	_servers.push_back(newServer);

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -50,27 +50,30 @@ void Server::run()
     Logger::info("Starting up network engines...");
     const std::vector<ServerConfig>& servers = _config.getServers();
 
-    std::set<int> unique_ports;
+    std::set<std::string> unique_endpoints;
     for (size_t i = 0; i < servers.size(); ++i)
     {
-        unique_ports.insert(servers[i].port);
+		unique_endpoints.insert(servers[i].host + ":" + StringUtils::to_string(servers[i].port));
     }
 
     std::vector<SocketEngine*> engines;
     
-    for (std::set<int>::iterator it = unique_ports.begin(); it != unique_ports.end(); ++it)
+    for (size_t i = 0; i < servers.size(); ++i)
     {
-        int current_port = *it;
-        SocketEngine* engine = new SocketEngine(current_port);
+		const std::string endpoint = servers[i].host + ":" + StringUtils::to_string(servers[i].port);
+		if (unique_endpoints.find(endpoint) == unique_endpoints.end())
+			continue;
+		unique_endpoints.erase(endpoint);
+        SocketEngine* engine = new SocketEngine(servers[i].host, servers[i].port);
     try
     {
         engine->init();
         engines.push_back(engine);
-        Logger::info("Successfully initialized SocketEngine on port: " + StringUtils::to_string(current_port));
+		Logger::info("Successfully initialized SocketEngine on " + endpoint);
     }
     catch (const std::exception& e)
     {
-        Logger::error(std::string("Failed to initialize SocketEngine on port ") + StringUtils::to_string(current_port) + ": " + e.what());
+		Logger::error(std::string("Failed to initialize SocketEngine on ") + endpoint + ": " + e.what());
         delete engine;
     }
     }

--- a/src/network/Connection.cpp
+++ b/src/network/Connection.cpp
@@ -3,7 +3,9 @@
 #include "utils/StringUtils.hpp"
 #include <iostream>
 
-Connection::Connection(int fd, size_t maxBodySize) : _fd(fd), _parser(maxBodySize), _max_body_size(maxBodySize)
+Connection::Connection(int fd, size_t maxBodySize, const std::string& listeningHost, int listeningPort)
+	: _fd(fd), _parser(maxBodySize), _listening_host(listeningHost),
+	_listening_port(listeningPort), _max_body_size(maxBodySize)
 {
     Logger::info(std::string("New connection created on FD: ") + StringUtils::to_string(_fd));
     _last_activity = time(NULL);
@@ -21,6 +23,16 @@ Connection::~Connection()
 int Connection::getFd() const
 {
     return _fd;
+}
+
+const std::string& Connection::getListeningHost() const
+{
+	return _listening_host;
+}
+
+int Connection::getListeningPort() const
+{
+	return _listening_port;
 }
 
 void Connection::appendResponse(const std::string& data)

--- a/src/network/EventLoop.cpp
+++ b/src/network/EventLoop.cpp
@@ -23,14 +23,14 @@ EventLoop::~EventLoop()
 	_connections.clear(); 
 }
 
-size_t EventLoop::getMaxBodySizeForPort(int port) const
+size_t EventLoop::getMaxBodySizeForEndpoint(const std::string& host, int port) const
 {
 	size_t maxBodySize = 0;
 	bool hasUnlimited = false;
 
 	for (size_t i = 0; i < _servers.size(); ++i)
 	{
-		if (_servers[i].port == port)
+		if (_servers[i].host == host && _servers[i].port == port)
 		{
 			if (_servers[i].clientMaxBodySize == 0)
 				hasUnlimited = true;
@@ -55,7 +55,8 @@ size_t EventLoop::getMaxBodySizeForPort(int port) const
 	return maxBodySize;
 }
 
-const ServerConfig* EventLoop::matchServerConfig(const std::string& hostHeader) const
+const ServerConfig* EventLoop::matchServerConfig(const std::string& hostHeader,
+	const std::string& listeningHost, int listeningPort) const
 {
 	std::string host = hostHeader;
 
@@ -65,12 +66,14 @@ const ServerConfig* EventLoop::matchServerConfig(const std::string& hostHeader) 
 
 	for (size_t i = 0; i < _servers.size(); ++i)
 	{
-		if (_servers[i].serverName == host)
+		if (_servers[i].host == listeningHost && _servers[i].port == listeningPort
+			&& _servers[i].serverName == host)
 			return &_servers[i];
 	}
 
-	if (!_servers.empty())
-		return &_servers[0];
+	for (size_t i = 0; i < _servers.size(); ++i)
+		if (_servers[i].host == listeningHost && _servers[i].port == listeningPort)
+			return &_servers[i];
 	
 	return NULL;
 }
@@ -155,7 +158,7 @@ void EventLoop::run()
 		{
 			if (is_server_socket)
 			{
-				size_t max_body_size = getMaxBodySizeForPort(active_engine->getPort());
+				size_t max_body_size = getMaxBodySizeForEndpoint(active_engine->getHost(), active_engine->getPort());
 				Connection* new_conn = active_engine->acceptConnection(max_body_size);
 				if (new_conn != NULL)
 				{
@@ -226,7 +229,8 @@ void EventLoop::run()
 					if (it != headers.end())
 						host = it->second;
 					
-					const ServerConfig* current_config = matchServerConfig(host);
+					const ServerConfig* current_config = matchServerConfig(host,
+						conn->getListeningHost(), conn->getListeningPort());
 
 					if (conn->getParser().getVersion() == "HTTP/1.1" && host.empty())
 					{

--- a/src/network/SocketEngine.cpp
+++ b/src/network/SocketEngine.cpp
@@ -2,12 +2,13 @@
 #include "utils/Logger.hpp"
 #include "utils/StringUtils.hpp"
 
-SocketEngine::SocketEngine(int port) : _server_fd(-1), _port(port)
+SocketEngine::SocketEngine(int port) : _server_fd(-1), _host("0.0.0.0"), _port(port)
 {
-    std::memset(&_address, 0, sizeof(_address));
-    _address.sin_family = AF_INET;
-    _address.sin_addr.s_addr = INADDR_ANY;
-    _address.sin_port = htons(_port);
+}
+
+SocketEngine::SocketEngine(const std::string& host, int port)
+    : _server_fd(-1), _host(host), _port(port)
+{
 }
 
 SocketEngine::~SocketEngine()
@@ -20,44 +21,49 @@ SocketEngine::~SocketEngine()
 
 void SocketEngine::init()
 {
-    // 1. Create socket (IPv4, TCP)
-    _server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    struct addrinfo hints = {};
+    struct addrinfo* addresses = NULL;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    const char* bindHost = _host.c_str();
+    const std::string portText = StringUtils::to_string(_port);
+    const int addressResult = getaddrinfo(bindHost, portText.c_str(), &hints, &addresses);
+    if (addressResult != 0)
+        throw std::runtime_error(std::string("Error: getaddrinfo() failed: ") + gai_strerror(addressResult));
+
+    for (struct addrinfo* current = addresses; current != NULL; current = current->ai_next)
+    {
+        _server_fd = socket(current->ai_family, current->ai_socktype, current->ai_protocol);
+        if (_server_fd == -1)
+            continue;
+
+        int opt = 1;
+        if (setsockopt(_server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1
+            || fcntl(_server_fd, F_SETFL, O_NONBLOCK) == -1
+            || fcntl(_server_fd, F_SETFD, FD_CLOEXEC) == -1)
+        {
+            close(_server_fd);
+            _server_fd = -1;
+            continue;
+        }
+        if (bind(_server_fd, current->ai_addr, current->ai_addrlen) == 0)
+            break;
+        close(_server_fd);
+        _server_fd = -1;
+    }
+    freeaddrinfo(addresses);
     if (_server_fd == -1)
-    {
-        throw std::runtime_error("Error: socket() failed");
-    }
-
-    // 2. SO_REUSEADDR - allows immediate server restart without "Address already in use!" error
-    int opt = 1;
-    if (setsockopt(_server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1)
-    {
-        throw std::runtime_error("Error: sersockopt() failed");
-    }
-
-    // 3. Set socket to non-blocking mode and close-on-exec
-    if (fcntl(_server_fd, F_SETFL, O_NONBLOCK) == -1)
-    {
-        throw std::runtime_error("Error: fcntl(O_NONBLOCK) failed");
-    }
-
-    if (fcntl(_server_fd, F_SETFD, FD_CLOEXEC) == -1)
-    {
-        throw std::runtime_error("Error: fcntl(FD_CLOEXEC) failed");
-    }
-
-    // 4. Bind socket to address and port
-    if (bind(_server_fd, (struct sockaddr*)&_address, sizeof(_address)) == -1)
-    {
-        throw std::runtime_error("Error: bind() failed");
-    }
-
-    // 5. Start listening (backlog = SOMAXCONN for maximum queue size)
+        throw std::runtime_error("Error: bind() failed for " + _host + ":" + portText);
     if (listen(_server_fd, SOMAXCONN) == -1)
     {
+        close(_server_fd);
+        _server_fd = -1;
         throw std::runtime_error("Error: listen() failed");
     }
 
-    Logger::info(std::string("Server started and listening on port ") + StringUtils::to_string(_port) + "(FD: " + StringUtils::to_string(_server_fd) + ")");
+    Logger::info("Server started on " + _host + ":" + portText + " (FD: " + StringUtils::to_string(_server_fd) + ")");
 }
 
 Connection* SocketEngine::acceptConnection(size_t maxBodySize)
@@ -81,7 +87,7 @@ Connection* SocketEngine::acceptConnection(size_t maxBodySize)
     
     try
     {
-        return new Connection(client_fd, maxBodySize);
+		return new Connection(client_fd, maxBodySize, _host, _port);
     }
     catch (const std::exception& e)
     {
@@ -99,4 +105,9 @@ int SocketEngine::getFd() const
 int SocketEngine::getPort() const
 {
     return _port;
+}
+
+const std::string& SocketEngine::getHost() const
+{
+	return _host;
 }


### PR DESCRIPTION
Fixes #104

From now on we can now configure listen as:

listen 8080;                # all IPv4 interfaces
listen 127.0.0.1:8080;      # one IPv4 interface
listen localhost:8080;      # hostname resolved by getaddrinfo
listen [::1]:8080;          # IPv6 literal

Invalid ports, missing ports, malformed addresses, port 0, and ports above 65535 now make config loading fail with a clear error. Each server block must contain exactly one listen directive.

Implementation details:

1. Config.cpp parses and validates interface/port values without atoi.

2. Config.hpp stores the configured host per server.

3. SocketEngine.cpp binds the configured endpoint through getaddrinfo, using only functions permitted by the 42 whitelist.

4. Server.cpp creates one listening socket per unique host:port; multiple virtual hosts may share that endpoint.

5. Connection.cpp retains the endpoint that accepted the connection.

6. EventLoop.cpp matches Host only among virtual servers on that same endpoint, preventing cross-port/interface routing.

7. Added interface-example.conf:

Files changed:
- Config.hpp
- Connection.hpp
- EventLoop.hpp
- SocketEngine.hpp
- Config,cpp
- SocketEngine.cpp
- Server.cpp
- Connection.cpp
- EventLoop.cpp
- interface-example.conf